### PR TITLE
Add CMakeLists.txt for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,99 @@
+cmake_minimum_required(VERSION 3.1)
+project(Milton)
+
+if(APPLE)
+  add_subdirectory(third_party/SDL2-2.0.3)
+endif()
+
+add_executable(shadergen
+  src/shadergen.cc
+)
+
+add_executable(Milton WIN32 MACOSX_BUNDLE
+  src/milton.cc
+  src/memory.cc
+  src/gui.cc
+  src/persist.cc
+  src/color.cc
+  src/canvas.cc
+  src/profiler.cc
+  src/gl_helpers.cc
+  src/localization.cc
+  src/hardware_renderer.cc
+  src/utils.cc
+  src/hash.cc
+  src/vector.cc
+  src/sdl_milton.cc
+  src/StrokeList.cc
+  src/third_party_libs.cc
+)
+
+target_include_directories(Milton PRIVATE
+  src
+  third_party
+  third_party/imgui
+)
+
+if(WIN32)
+  target_sources(Milton PRIVATE
+    src/platform_windows.cc
+  )
+endif()
+
+if(UNIX)
+  target_sources(Milton PRIVATE
+    src/platform_unix.cc
+  )
+  target_compile_options(Milton PRIVATE
+    -std=c++11
+    -Wno-missing-braces
+    -Wno-unused-function
+    -Wno-unused-variable
+    -Wno-unused-result
+    -Wno-write-strings
+    -Wno-c++11-compat-deprecated-writable-strings
+    -Wno-null-dereference
+    -Wno-format
+    -fno-strict-aliasing
+    -fno-omit-frame-pointer
+    -Wno-extern-c-compat
+    -Werror
+  )
+endif()
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  target_sources(Milton PRIVATE
+    src/platform_linux.cc
+  )
+endif()
+
+if(APPLE)
+  target_sources(Milton PRIVATE
+    src/platform_mac.cc
+  )
+  target_link_libraries(Milton
+    SDL2-static
+    "-framework OpenGL"
+  )
+endif()
+
+if(WIN32 OR APPLE)
+  target_include_directories(Milton PRIVATE
+    third_party/SDL2-2.0.3/include
+  )
+endif()
+
+add_custom_command(TARGET Milton POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_LIST_DIR}/milton_icon.ico
+    ${CMAKE_CURRENT_LIST_DIR}/third_party/Carlito.ttf
+    ${CMAKE_CURRENT_LIST_DIR}/third_party/Carlito.LICENSE
+    $<TARGET_FILE_DIR:Milton>
+)
+
+add_dependencies(Milton shadergen)
+
+add_custom_command(TARGET Milton PRE_BUILD
+  COMMAND $<TARGET_FILE:shadergen>
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+)


### PR DESCRIPTION
I've started on CMake integration for a few reasons. Current version builds a macOS bundle, copies in necessary files, and runs shadergen. Just needs missing link/includes for Linux and Windows (shouldn't be too much more code). The result should actually be a smaller project file than what Tundra requires.

1. CMake has become the industry standard for C++ projects (used by LLVM, Swift, KDE, MySQL, [others](https://en.wikipedia.org/wiki/CMake#Notable_applications))
2. Tundra has been in beta for years
3. SDL is CMake-based, so we just need `add_subdirectory()` and `target_link_libraries()` to integrate it into the project. Now it builds natively (worked great with CMake's Xcode generator). We may even be able to compile that for Windows too, and get rid of the binary file in the repository.

Feel free to reject, just thought I'd put this out there.