### PR TITLE
Implement macOS dialogs

### DIFF
--- a/src/platform_mac.cc
+++ b/src/platform_mac.cc
@@ -1,5 +1,3 @@
-#define IMPL_MISSING mlt_assert(!"IMPLEMENT")
-
 #include <mach-o/dyld.h>
 #include <errno.h>
 #include <limits.h>
@@ -59,14 +57,16 @@ platform_delete_file_at_config(PATH_CHAR* fname, int error_tolerance)
 void
 platform_dialog(char* info, char* title)
 {
-    IMPL_MISSING;
+    extern void platform_dialog_mac(char*, char*);
+    platform_dialog_mac(info, title);
     return;
 }
 
 b32
 platform_dialog_yesno(char* info, char* title)
 {
-    IMPL_MISSING;
+    extern b32 platform_dialog_yesno_mac(char*, char*);
+    platform_dialog_yesno_mac(info, title);
     return false;
 }
 
@@ -125,19 +125,20 @@ platform_move_file(PATH_CHAR* src, PATH_CHAR* dest)
 PATH_CHAR*
 platform_open_dialog(FileKind kind)
 {
-    IMPL_MISSING;
-    return NULL;
+    extern PATH_CHAR* platform_open_dialog_mac(FileKind);
+    return platform_open_dialog_mac(kind);
 }
 void
 platform_open_link(char* link)
 {
-    return;
+    extern void platform_open_link_mac(char*);
+    platform_open_link_mac(link);
 }
 PATH_CHAR*
 platform_save_dialog(FileKind kind)
 {
-    IMPL_MISSING;
-    return NULL;
+    extern PATH_CHAR* platform_save_dialog_mac(FileKind);
+    return platform_save_dialog_mac(kind);
 }
 //  ====
 

--- a/src/platform_mac_gui.mm
+++ b/src/platform_mac_gui.mm
@@ -1,0 +1,83 @@
+#include <AppKit/AppKit.h>
+
+// FileKind is temporarily redefined because when SDL is included in an Objective-C file
+// it brings with it Carbon's old Rect type, which conflicts with Milton's Rect type.
+enum FileKind
+{
+    FileKind_IMAGE,
+    FileKind_MILTON_CANVAS,
+    
+    FileKind_COUNT,
+};
+
+namespace {
+    template <typename T>
+    char* runPanel(T *panel, FileKind kind) {
+        switch (kind) {
+            case FileKind_IMAGE:
+                panel.allowedFileTypes = @[(NSString*)kUTTypeJPEG];
+                break;
+            case FileKind_MILTON_CANVAS:
+                panel.allowedFileTypes = @[@"mlt"];
+                break;
+            default:
+                break;
+        }
+        if ([panel runModal] != NSFileHandlingPanelOKButton) {
+            return nullptr;
+        }
+        return strdup(panel.URL.path.fileSystemRepresentation);
+    }
+    
+    NSAlert* alertWithInfoTitle(const char* info, const char* title) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = [NSString stringWithUTF8String:title ? title : ""];
+        alert.informativeText = [NSString stringWithUTF8String:info ? info : ""];
+        return alert;
+    }
+}
+
+void
+platform_dialog_mac(char* info, char* title)
+{
+    @autoreleasepool {
+        [alertWithInfoTitle(info, title) runModal];
+    }
+}
+
+int32_t
+platform_dialog_yesno_mac(char* info, char* title)
+{
+    @autoreleasepool {
+        NSAlert *alert = alertWithInfoTitle(info, title);
+        [alert addButtonWithTitle:NSLocalizedString(@"Yes", nil)];
+        [alert addButtonWithTitle:NSLocalizedString(@"No", nil)];
+        return [alert runModal] == NSAlertFirstButtonReturn;
+    }
+}
+
+char*
+platform_open_dialog_mac(FileKind kind)
+{
+    @autoreleasepool {
+        return runPanel([NSOpenPanel openPanel], kind);
+    }
+}
+
+char*
+platform_save_dialog_mac(FileKind kind)
+{
+    @autoreleasepool {
+        return runPanel([NSSavePanel savePanel], kind);
+    }
+}
+
+void
+platform_open_link_mac(char* link)
+{
+    @autoreleasepool {
+        NSURL *url = [NSURL URLWithString:[NSString stringWithUTF8String:link]];
+        [[NSWorkspace sharedWorkspace] openURL:url];
+    }
+}
+

--- a/tundra.lua
+++ b/tundra.lua
@@ -92,6 +92,7 @@ Build {
                 {"src/platform_unix.cc"; Config = { "linux-*", "macos" }},
                 {"src/platform_linux.cc"; Config = { "linux-*" }},
                 {"src/platform_mac.cc"; Config = { "macos" }},
+                {"src/platform_mac_gui.mm"; Config = { "macos" }},
                 "src/third_party_libs.cc",
 
                 { ResourceFile { Input="Milton.rc" }; Config="win*" },
@@ -215,6 +216,7 @@ Build {
                     "-Werror",
                     "-O0",
                     "-g",
+                    "-fobjc-arc"
                 },
                 SHADERGEN_BIN = "./$(OBJECTROOT)$(SEP)$(BUILD_ID)$(SEP)shadergen",
             },


### PR DESCRIPTION
I went ahead and implemented this, just tested by putting each function in milton_main.

Added separate file instead of renaming existing file because when an Objective-C file imports SDL it imports Carbon’s legacy Rect struct which conflicts with Milton’s Rect.