### PR TITLE
Cleaner zoom number

### DIFF
--- a/src/gui.cc
+++ b/src/gui.cc
@@ -303,11 +303,11 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform_state,  MiltonStat
         char msg[1024];
         WallTime lst = milton_state->last_save_time;
 
-        snprintf(msg, 1024, "\t%s -- Last saved: %.2d:%.2d:%.2d\t\tZoom level %f",
+        snprintf(msg, 1024, "\t%s -- Last saved: %.2d:%.2d:%.2d\t\tZoom level %.0f",
                  (milton_state->flags & MiltonStateFlags_DEFAULT_CANVAS) ? "[Default canvas]" :
                  file_name,
                  lst.hours, lst.minutes, lst.seconds,
-                 log2(1 + milton_state->view->scale / (double)MILTON_DEFAULT_SCALE));
+                 log2(1 + milton_state->view->scale / (double)MILTON_DEFAULT_SCALE) * 1000);
 
         if ( ImGui::BeginMenu(msg, /*bool enabled = */false) ) {
             ImGui::EndMenu();


### PR DESCRIPTION
It's harder to read the zoom level when it has many decimal places. Instead, multiply it by 1000 and remove the remaining decimals.