### PR TITLE
Cast int to int* before cmp.

### DIFF
--- a/src/hardware_renderer.cc
+++ b/src/hardware_renderer.cc
@@ -1539,7 +1539,7 @@ gpu_render(RenderData* render_data,  i32 view_x, i32 view_y, i32 view_width, i32
         // Draw outline.
         glUseProgram(render_data->exporter_program);
         GLint loc = glGetAttribLocation(render_data->exporter_program, "a_position");
-        if ( loc>=0 && render_data->vbo_exporter>0 ) {
+        if ( loc>=0 && render_data->vbo_exporter>(void *)0 ) {
             for ( int vbo_i = 0; vbo_i < 4; ++vbo_i ) {
                 DEBUG_gl_validate_buffer(render_data->vbo_exporter[vbo_i]);
                 glBindBuffer(GL_ARRAY_BUFFER, render_data->vbo_exporter[vbo_i]);


### PR DESCRIPTION
on linux clang is complaining about this pointer comparison against an int, this cast make it at least compile, i'm not sure if it was meant to check if it's a valid pointer or pointer value higher than 0 (typo to *(pointer) > 0)
here is clang output before this patch
> milton/src/hardware_renderer.cc:1542:49: error: ordered comparison between pointer and zero ('GLuint *' (aka 'unsigned int *') and 'int')
        if ( loc>=0 && render_data->vbo_exporter>0) {
                       ~~~~~~~~~~~~~~~~~~~~~~~~~^~