### PR TITLE
Fix a crash

### DIFF
--- a/src/gui.cc
+++ b/src/gui.cc
@@ -126,6 +126,7 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform_state,  MiltonStat
 
                 // New Canvas
                 milton_reset_canvas_and_set_default(milton_state);
+                canvas = milton_state->canvas;
                 input->flags |= MiltonInputFlags_FULL_REFRESH;
                 milton_state->flags |= MiltonStateFlags_DEFAULT_CANVAS;
             }


### PR DESCRIPTION
When the canvas is unsaved, selecting the "New Canvas" dialog in the menu, choosing either option can sometimes crash the program, specifically on https://github.com/serge-rgb/milton/blob/04354239d31f479ed245de7e7a3bd1570e26a80b/src/gui.cc#L424

This happens because `milton_reset_canvas_and_set_default` calls `arena_bootstrap` on `milton_state->canvas`, but due to the nature of the arena system this may actually change the pointer of `canvas`.

In `milton_imgui_tick` there is a local var `canvas` that gets assigned at the beginning of the function. When `milton_state->canvas` changes, the local `canvas` is not updated and will cause a crash because it points to a faulty memory address.

What my patch does is update the `canvas` variable right after the canvas is reset. This fixes the issue.