### PR TITLE
Stubs and CMake improvements for linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ if(WIN32)
   set(DIRECTX 0)
 endif()
 
-add_subdirectory(third_party/SDL2-2.0.3)
 
 add_executable(shadergen
   src/shadergen.cc
@@ -50,9 +49,9 @@ if(UNIX)
     -g
     -std=c++11
     -Wno-missing-braces
-    #-Wno-unused-function
-    #-Wno-unused-variable
-    #-Wno-unused-result
+    -Wno-unused-function
+    -Wno-unused-variable
+    -Wno-unused-result
     -Wno-write-strings
     -Wno-c++11-compat-deprecated-writable-strings
     -Wno-null-dereference
@@ -72,9 +71,54 @@ if(UNIX)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+
   target_sources(Milton PRIVATE
     src/platform_linux.cc
   )
+
+  find_package(OpenGL REQUIRED)
+  find_package(SDL2 REQUIRED)
+  find_package(GTK2 2.6 REQUIRED gtk)
+  find_package(X11 REQUIRED)
+  find_library(XINPUT_LIBRARY libXi.so)
+
+  if(XINPUT_LIBRARY STREQUAL "XINPUT_LIBRARY-NOTFOUND")
+      message(FATAL_ERROR "Could not find libXi.so")
+  endif()
+
+  if(NOT OPENGL_FOUND)
+      message(FATAL_ERROR "Could not find OpenGl libraries")
+  endif()
+
+  if(NOT GTK2_FOUND)
+    message(FATAL_ERROR "Could not find GTK2.8 libraries")
+  endif()
+
+  if(NOT X11_FOUND)
+    message(FATAL_ERROR "Could not find X11 libraries")
+  endif()
+
+  if(NOT SDL2_FOUND)
+    message(FATAL_ERROR "Could not find SDL2 libraries")
+  endif()
+
+  target_include_directories(Milton PRIVATE
+    ${GTK2_INCLUDE_DIRS}
+    ${X11_INCLUDE_DIR}
+    ${SDL2_INCLUDE_DIRS}
+    ${OPENGL_INCLUDE_DIR}
+  )
+
+  target_link_libraries(Milton 
+    ${GTK2_LIBRARIES}
+    ${X11_LIBRARIES}
+    ${SDL2_LIBRARIES}
+    ${OPENGL_LIBRARIES}
+    ${XINPUT_LIBRARY})
+  
+else()
+  add_subdirectory(third_party/SDL2-2.0.3)
+  target_link_libraries(Milton SDL2-static)
 endif()
 
 if(APPLE)
@@ -85,7 +129,6 @@ if(APPLE)
     "-framework OpenGL"
   )
 endif()
-target_link_libraries(Milton SDL2-static)
 
 
 if(WIN32 OR APPLE)

--- a/src/common.h
+++ b/src/common.h
@@ -40,7 +40,7 @@ typedef i32         b32;
     #elif defined(__GNUC__)  // Clang defines this too
         #define ALIGN(n) __attribute__(( aligned (n) ))
     #else
-        #error I don't know how to align stuff in this compiler
+        #error I dont know how to align stuff in this compiler
     #endif
 #endif // ALIGN
 

--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -32,17 +32,27 @@ perf_counter()
 }
 
 void
-platform_point_to_pixel(PlatformState*, v2l*)
+platform_point_to_pixel(PlatformState* ps, v2l* inout)
 {
 
 }
 
 void
-platform_point_to_pixel_i(PlatformState*, v2i*)
+platform_point_to_pixel_i(PlatformState* ps, v2i* inout)
 {
 
 }
 
+float
+platform_ui_scale(PlatformState* p)
+{
+    return 1.0f;
+}
+
+void 
+platform_pixel_to_point(PlatformState* ps, v2l* inout)
+{
+}
 
 b32
 platform_delete_file_at_config(PATH_CHAR* fname, int error_tolerance)


### PR DESCRIPTION
I had some issues building for linux so I fixed them.

The main course is the CMake. It disregards the inlined SDL2 source and finds the precompiled binaries on disk along with X11, XInput, OpenGL and GTK2

The side dish would be the couple of stub's in platform_linux.cpp, the most interesting one being platform_ui_scale for it returns 1.

Now it builds for me. Stylus pressure works too BTW.

![2017-11-30-150205_1915x1079_scrot](https://user-images.githubusercontent.com/10726335/33439293-fe6f979c-d5e4-11e7-800e-d4be594f4572.png)
