### PR TITLE
Fixed CMake warning on Ubuntu 16.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,11 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     message(FATAL_ERROR "Could not find SDL2 libraries")
   endif()
 
+  # on ubuntu 16.04 LTS CMake complains about the -lSDL2 link switch
+  # having trailing/leading spaces.
+  # string(STRIP a b) will remove those spaces.
+  string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES)
+
   target_include_directories(Milton PRIVATE
     ${GTK2_INCLUDE_DIRS}
     ${X11_INCLUDE_DIR}
@@ -115,7 +120,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     ${SDL2_LIBRARIES}
     ${OPENGL_LIBRARIES}
     ${XINPUT_LIBRARY})
-  
+
 else()
   add_subdirectory(third_party/SDL2-2.0.3)
   target_link_libraries(Milton SDL2-static)


### PR DESCRIPTION
CMake complains about trailing spaces in the link targets on Ubuntu.

![2017-12-02-141217_697x194_scrot](https://user-images.githubusercontent.com/10726335/33516448-da809b6a-d76a-11e7-9f94-52214225adaa.png)

This fixes it by removing any trailing/leading whitespaces by using string(STRIP a b)
