### PR TITLE
CMake switches for OpenGL2/3, Release and Debug. Fixed a possible overflow in linux platform_fname_at_config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,10 @@ add_definitions(-DIS_USING_CMAKE=1)
 
 if(TRY_GL2)
   message(STATUS "Compiling for OpenGL2.1")
-  add_definitions(-DCMAKE_FORCE_GL2=1)
+  add_definitions(-DCMAKE_TRY_GL2=1)
 elseif(TRY_GL3)
   message(STATUS "Compiling for OpenGL3.2")
-  add_definitions(-DCMAKE_FORCE_GL3=1)
+  add_definitions(-DCMAKE_TRY_GL3=1)
 endif()
 
 ## Default build type to Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ else()
   message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}. Supported build types: Release, Debug.")
 endif()
 
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+
 message(STATUS "Building ${CMAKE_BUILD_TYPE}")
 
 # Platform specific stuff
@@ -75,7 +78,6 @@ endif()
 
 if(UNIX)
   set(UnixCFlags
-    -g
     -std=c++11
     -Wno-missing-braces
     -Wno-unused-function

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,35 @@ target_include_directories(Milton PRIVATE
   third_party/imgui
 )
 
+# Handle various switches, build types etc.
+
+## Helps to know that we're compiling using cmake in milton_configuration.h
+add_definitions(-DIS_USING_CMAKE=1)
+
+if(TRY_GL2)
+  message(STATUS "Compiling for OpenGL2.1")
+  add_definitions(-DCMAKE_FORCE_GL2=1)
+elseif(TRY_GL3)
+  message(STATUS "Compiling for OpenGL3.2")
+  add_definitions(-DCMAKE_FORCE_GL3=1)
+endif()
+
+## Default build type to Release
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_definitions(-DMILTON_DEBUG=1)
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+  add_definitions(-DMILTON_DEBUG=0)
+else()
+  message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}. Supported build types: Release, Debug.")
+endif()
+
+message(STATUS "Building ${CMAKE_BUILD_TYPE}")
+
+# Platform specific stuff
 if(WIN32)
   target_sources(Milton PRIVATE
     src/platform_windows.cc

--- a/README.md
+++ b/README.md
@@ -68,8 +68,33 @@ Linux
 
 Porting in progress.
 
-Build it with `make` and run it with `build/milton`. You need to install the SDL libraries (`libsdl2-dev` on Ubuntu).
+### Building
 
+Library and header dependencies:
+* X11
+* SDL2
+* OpenGL
+* XInput
+* GTK2
+
+Release build using CMake:
+```sh
+mkdir build
+cmake ..
+make
+./Milton
+```
+
+There are some CMake options you might care about:
+
+| flag | type | does |
+| ---- | ---- | ---- |
+| `TRY_GL2` | `bool` | Tells Milton to target OpenGL2.1. Does not guarantee that such a context will be created. This is the default Release target. |
+| `TRY_GL3` | `bool` | Tells Milton to target OpenGL3.2. Does not guarantee that such a context will be created. This is the default Debug target. |
+| `CMAKE_BUILD_TYPE` | `string` | Configures the build type. Defaults to `Release`. Available build types are: `Release` and `Debug`. |
+
+Example debug build using GL2.1:
+`cmake -DCMAKE_BUILD_TYPE=Debug -DTRY_GL2=1 ..`
 
 OSX
 ---

--- a/src/milton_configuration.h
+++ b/src/milton_configuration.h
@@ -8,12 +8,14 @@
 #define MILTON_MINOR_VERSION 5
 #define MILTON_MICRO_VERSION 2
 
-#define MILTON_DEBUG 1
+#if !defined(IS_USING_CMAKE)
+    #define MILTON_DEBUG 1
+#endif
 
 #define MILTON_ZOOM_DEBUG 0
     // Force MILTON_ZOOM_DEBUG to 0 if MILTON_DEBUG is 0.
 #if !MILTON_DEBUG
-    #undef MILTON_ZOOM_DEBUG;
+    #undef MILTON_ZOOM_DEBUG
     #define MILTON_ZOOM_DEBUG 0
 #endif
 
@@ -62,3 +64,12 @@
 // Spawn threads to save the canvas.
 #define MILTON_SAVE_ASYNC 1
 
+#ifdef CMAKE_TRY_GL2
+    #undef USE_GL_3_2
+    #define USE_GL_3_2 0
+#endif
+
+#ifdef CMAKE_TRY_GL3
+    #undef USE_GL_3_2
+    #define USE_GL_3_2 1
+#endif

--- a/src/sdl_milton.cc
+++ b/src/sdl_milton.cc
@@ -666,9 +666,11 @@ milton_main(bool is_fullscreen, char* file_to_open)
 #if USE_GL_3_2
     i32 gl_version_major = 3;
     i32 gl_version_minor = 2;
+    milton_log("Requesting OpenGL 3.2 context.\n");
 #else
     i32 gl_version_major = 2;
     i32 gl_version_minor = 1;
+    milton_log("Requesting OpenGL 2.1 context.\n");
 #endif
 
     SDL_Window* window = NULL;


### PR DESCRIPTION
### CMake

* `IS_USING_CMAKE` will be defined if compiling with CMake.
* If `IS_USING_CMAKE` is not set, we set`MILTON_DEBUG=1`
* New command line goodies:
  * `-DTRY_GL2=1` will define `CMAKE_TRY_GL2` which sets `USE_GL_3_2=0`
  * `-DTRY_GL2=3` will define `CMAKE_TRY_GL3` which sets `USE_GL_3_2=1`
  * Build types that do something. `-DCMAKE_BUILD_TYPE=Release` compiles with `-O3`optimization. `-DCMAKE_BUILD_TYPE=Debug` sets `MILTON_DEBUG=1` and compiles with `-g`

I don't have access to a windows machine so I can't confirm if the CMake changes will work on windows.

### Linux

* Fixed a possible overflow in linux `platform_fname_at_config`. `strncat` was being called with the max character paramater being the size of the target buffer and not the remaining space in it. We now count how many characters the final `fname` will occupy and if it's above `len` we simply return the original `fname` as it may be used as a relative path.

* Added a building writeup for Linux to README.md

### Misc

* We now log what version OpenGL context we request.
* Removed a loose semicolon in milton_configuration.h defines



