### PR TITLE
fix linux platform_fopen

### DIFF
--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -181,7 +181,7 @@ platform_fname_at_exe(PATH_CHAR* fname, size_t len)
 FILE*
 platform_fopen(const PATH_CHAR* fname, const PATH_CHAR* mode)
 {
-    FILE* fd = fopen_unix(fname, mode);
+    FILE *fd = fopen(fname, mode);
     return fd;
 }
 

--- a/src/platform_unix.h
+++ b/src/platform_unix.h
@@ -60,5 +60,3 @@ void unix_log(char* format, ...);
 // Include header for our SDL hook.
 #include "platform_OSX_SDL_hooks.h"
 #endif
-
-FILE* fopen_unix(const char* fname, const char* mode);


### PR DESCRIPTION
In aab239225a1145e0be48f71b95daf0584c2f36d0 you removed fopen_unix but only changed platorm_mac. This just does the same change in platform_linux.