### PR TITLE
Refined the linux build process a bit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(shadergen
   src/shadergen.cc
 )
 
+set(SDL2DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/SDL2-2.0.3)
+
 FILE (GLOB ShaderSources src/*.glsl third_party/*.glsl)
 
 add_executable(Milton WIN32 MACOSX_BUNDLE
@@ -108,10 +110,10 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   )
 
   find_package(OpenGL REQUIRED)
-  find_package(SDL2 REQUIRED)
   find_package(GTK2 2.6 REQUIRED gtk)
   find_package(X11 REQUIRED)
   find_library(XINPUT_LIBRARY libXi.so)
+  find_package(Threads REQUIRED)
 
   if(XINPUT_LIBRARY STREQUAL "XINPUT_LIBRARY-NOTFOUND")
       message(FATAL_ERROR "Could not find libXi.so")
@@ -129,31 +131,26 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     message(FATAL_ERROR "Could not find X11 libraries")
   endif()
 
-  if(NOT SDL2_FOUND)
-    message(FATAL_ERROR "Could not find SDL2 libraries")
-  endif()
-
-  # on ubuntu 16.04 LTS CMake complains about the -lSDL2 link switch
-  # having trailing/leading spaces.
-  # string(STRIP a b) will remove those spaces.
-  string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES)
-
   target_include_directories(Milton PRIVATE
     ${GTK2_INCLUDE_DIRS}
     ${X11_INCLUDE_DIR}
-    ${SDL2_INCLUDE_DIRS}
+    ${SDL2DIR}/build/linux64/include/SDL2
     ${OPENGL_INCLUDE_DIR}
   )
 
   target_link_libraries(Milton
     ${GTK2_LIBRARIES}
     ${X11_LIBRARIES}
-    ${SDL2_LIBRARIES}
     ${OPENGL_LIBRARIES}
-    ${XINPUT_LIBRARY})
+    ${XINPUT_LIBRARY}
+    ${SDL2DIR}/build/linux64/lib/libSDL2main.a
+    ${SDL2DIR}/build/linux64/lib/libSDL2.a
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CMAKE_DL_LIBS}
+    )
 
 else()
-  add_subdirectory(third_party/SDL2-2.0.3)
+  add_subdirectory(${SDL2DIR})
   target_link_libraries(Milton SDL2-static)
 endif()
 
@@ -169,7 +166,7 @@ endif()
 
 if(WIN32 OR APPLE)
   target_include_directories(Milton PRIVATE
-    third_party/SDL2-2.0.3/include
+    ${SDL2DIR}/include
   )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here is the  [latest video tutorial](https://www.youtube.com/watch?v=g27gHio2Ohk
 
 Check out the [patreon page](https://www.patreon.com/serge_rgb?ty=h) if you would like to help out. :)
 
-Milton is Windows only at the moment. Linux and OSX support is intended for the future, but I don't know when that will come.
+While on Windows there are binaries available, for Milton on Linux or OSX you will have to compile from source. There are some basic build instructions below. They will probably build, but please be prepared to do a bit of debugging on your end if you run into trouble, since these are not the primary development platforms.
 
 How to Compile
 ==============
@@ -66,26 +66,26 @@ installed.
 Linux
 -----
 
-Porting in progress.
+Work in progress, but is known to build and run.
 
-### Building
-
-Library and header dependencies:
+### Dependencies
+Use your linux distribution's package manager to install these.
 * X11
-* SDL2
 * OpenGL
 * XInput
 * GTK2
 
-Release build using CMake:
+### Building
+
+Release build:
 ```sh
-mkdir build
-cmake ..
-make
-./Milton
+./build-lin.sh
+build/Milton
 ```
 
-There are some CMake options you might care about:
+build-lin.sh uses cmake under the hood, and any arguments you pass to it will be passed along to cmake.
+
+Here are some CMake options you might care about:
 
 | flag | type | does |
 | ---- | ---- | ---- |
@@ -93,14 +93,19 @@ There are some CMake options you might care about:
 | `TRY_GL3` | `bool` | Tells Milton to target OpenGL3.2. Does not guarantee that such a context will be created. This is the default Debug target. |
 | `CMAKE_BUILD_TYPE` | `string` | Configures the build type. Defaults to `Release`. Available build types are: `Release` and `Debug`. |
 
+
 Example debug build using GL2.1:
-`cmake -DCMAKE_BUILD_TYPE=Debug -DTRY_GL2=1 ..`
+`./build-lin.sh -DCMAKE_BUILD_TYPE=Debug -DTRY_GL2=1`
 
 OSX
 ---
 
-_No OSX support at the moment._
+Work in progress.
 
+### Building
+`./setup_osx.sh`
+
+If you run into troubles building on OSX, please try to submit a pull request if possible.
 
 License
 =======

--- a/build-lin.sh
+++ b/build-lin.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $MYDIR
+
+# Build and install the cmake static library and headers into a subdirectory
+# Specifically: third_party/SDL2-2.0.3/build/linux64/{lib,include}
+#
+# This really should become an ExternalProject_Add inside the CMakelists.txt
+# and windows, linux, and osx should all use the same approach for building cmake.
+pushd third_party/SDL2-2.0.3
+    CMAKE_CMD='cmake
+    -D ARTS:BOOL=OFF
+    -D ALSA:BOOL=OFF
+    -D PULSEAUDIO:BOOL=OFF
+    -D OSS:BOOL=OFF
+    -D ESD:BOOL=OFF
+    -D SDL_SHARED:BOOL=OFF
+    -D CMAKE_INSTALL_PREFIX="../linux64"
+    -G "Unix Makefiles"
+    -D CMAKE_DEBUG_POSTFIX="_debug"
+    '
+
+    mkdir -p build/linrelease
+    pushd build/linrelease
+        eval $CMAKE_CMD -D CMAKE_BUILD_TYPE="Release" ../.. || exit 1
+        make -j install || exit 1
+    popd
+popd
+
+mkdir -p build
+cd build
+
+cmake $@ .. || exit 1
+make -j || exit 1


### PR DESCRIPTION
Introduced a build-lin.sh bash script that does the following:
1. Builds cmake and installs its static libraries and linux-specific headers
    into the third_party/SDL2-2.0.3/build/linux64/{lib,include} directories.
2. Build Milton, linking with the SDL libs that were created in step 1.

Prior to this commit, cmake would try to use the system-installed SDL2, which
has a couple of annoyances:
1. It's not uncommon for a system not to have SDL2, so the user has to install it.
   It might be a different version than the one that Milton was written to work with,
   potentially causing difficult-to-track-down bugs.
2. There was not a FindSDL2.cmake module packaged along with Milton, which could mean
   an irritating process of trying to get cmake to find where the SDL2 libraries and
   headers live on a system. This is actually what bit me when I tried to build the
   linux version.

Finaly, Milton already includes a copy of the SDL2 library in its repo which
it uses for windows builds, so we should just use the included copy on linux too!
:)

There are also some other smaller improvements such as:
* Using a variable for the third_party/sdl2 directory so it isn't repeated a lot in CMakeLists.txt
* Ensuring CMakeLists.txt require libpthread and libdl on linux linker errors would happen otherwise.

For the future:
The cmake command used to build SDL2 inside of the build-lin.sh script should probably be made into
a 'ExternalProject_Add' statement inside the CMakelists.txt file, and used across all platforms this way
to build sdl2, and overall the amount of `if(linux) x else y` situations in the cmake script should be
reduced greatly.
This ExternalProject_Add would also replace the current add_subdirectory() statement in CMakeLists.txt.
The reason I think this is necessary is that on linux, the install process of the SDL2 project actually
needs to be executed in order to produce header files that work on linux (contain the necessary X11 content);
It's apparently not sufficient to just use third_party/SDL2-2.0.3/include directory like you can on windows.