### PR TITLE
Change layer renaming to double clicking

### DIFF
--- a/src/gui.cc
+++ b/src/gui.cc
@@ -35,6 +35,7 @@ gui_layer_window(MiltonInput* input, PlatformState* platform, Milton* milton, f3
         static i32 layer_renaming_idx = -1;
         static b32 focus_rename_field = false;
 
+
         Layer* layer = milton->canvas->root_layer;
         while ( layer->next ) { layer = layer->next; }  // Move to the top layer.
         while ( layer ) {
@@ -50,8 +51,11 @@ gui_layer_window(MiltonInput* input, PlatformState* platform, Milton* milton, f3
             ImGui::PopID();
             ImGui::SameLine();
 
-            // TODO(michalc): clicking anywhere else than on the layer should cancel
-            // the name change
+            // Draw the layers list. If in renaming mode, draw the layer that's being renamed as an InputText.
+            // Else just draw them as a list of Selectables.
+            if ( !ImGui::IsWindowFocused() ) {
+                is_renaming = false;
+            }
 
             if ( is_renaming ) {
                 if ( layer->id == layer_renaming_idx ) {
@@ -74,7 +78,6 @@ gui_layer_window(MiltonInput* input, PlatformState* platform, Milton* milton, f3
                                            milton->canvas->working_layer == layer,
                                            ImGuiSelectableFlags_AllowDoubleClick) ) {
                         if ( ImGui::IsMouseDoubleClicked(0) ) {
-                            // TODO(michalc): add setting the layer name
                             layer_renaming_idx = layer->id;
                             focus_rename_field = true;
                         }
@@ -88,7 +91,6 @@ gui_layer_window(MiltonInput* input, PlatformState* platform, Milton* milton, f3
                                        milton->canvas->working_layer == layer,
                                        ImGuiSelectableFlags_AllowDoubleClick) ) {
                     if ( ImGui::IsMouseDoubleClicked(0) ) {
-                        // TODO(michalc): add setting the layer name
                         layer_renaming_idx = layer->id;
                         is_renaming = true;
                         focus_rename_field = true;

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -31,20 +31,72 @@ gui_layer_window(MiltonInput* input, PlatformState* platform, Milton* milton, f3
         // left
         ImGui::BeginChild("left pane", ImVec2(150, 0), true);
 
+        static b32 is_renaming = false;
+        static i32 layer_renaming_idx = -1;
+        static b32 focus_rename_field = false;
+
         Layer* layer = milton->canvas->root_layer;
         while ( layer->next ) { layer = layer->next; }  // Move to the top layer.
         while ( layer ) {
+
             bool v = layer->flags & LayerFlags_VISIBLE;
             ImGui::PushID(layer->id);
+
             if ( ImGui::Checkbox("##select", &v) ) {
                 layer::layer_toggle_visibility(layer);
                 input->flags |= (i32)MiltonInputFlags_FULL_REFRESH;
             }
+
             ImGui::PopID();
             ImGui::SameLine();
-            if ( ImGui::Selectable(layer->name, milton->canvas->working_layer == layer) ) {
-                milton_set_working_layer(milton, layer);
+
+            // TODO(michalc): clicking anywhere else than on the layer should cancel
+            // the name change
+
+            if ( is_renaming ) {
+                if ( layer->id == layer_renaming_idx ) {
+                    if ( focus_rename_field ) {
+                        ImGui::SetKeyboardFocusHere(0);
+                        focus_rename_field = false;
+                    }
+                    if ( ImGui::InputText("##rename",
+                                          milton->canvas->working_layer->name,
+                                          13,
+                                          //MAX_LAYER_NAME_LEN,
+                                          ImGuiInputTextFlags_EnterReturnsTrue
+                                          //,ImGuiInputTextFlags flags = 0, ImGuiTextEditCallback callback = NULL, void* user_data = NULL
+                                         )) {
+                        is_renaming = false;
+                    }
+                }
+                else {
+                    if ( ImGui::Selectable(layer->name,
+                                           milton->canvas->working_layer == layer,
+                                           ImGuiSelectableFlags_AllowDoubleClick) ) {
+                        if ( ImGui::IsMouseDoubleClicked(0) ) {
+                            // TODO(michalc): add setting the layer name
+                            layer_renaming_idx = layer->id;
+                            focus_rename_field = true;
+                        }
+                        is_renaming = false;
+                        milton_set_working_layer(milton, layer);
+                    }
+                }
             }
+            else {
+                if ( ImGui::Selectable(layer->name,
+                                       milton->canvas->working_layer == layer,
+                                       ImGuiSelectableFlags_AllowDoubleClick) ) {
+                    if ( ImGui::IsMouseDoubleClicked(0) ) {
+                        // TODO(michalc): add setting the layer name
+                        layer_renaming_idx = layer->id;
+                        is_renaming = true;
+                        focus_rename_field = true;
+                    }
+                    milton_set_working_layer(milton, layer);
+                }
+            }
+
             layer = layer->prev;
         }
         ImGui::EndChild();
@@ -145,32 +197,6 @@ gui_layer_window(MiltonInput* input, PlatformState* platform, Milton* milton, f3
         ImGui::EndChild();
         ImGui::BeginChild("buttons");
 
-        static b32 is_renaming = false;
-        if ( is_renaming == false ) {
-            ImGui::Text(milton->canvas->working_layer->name);
-            ImGui::Indent();
-            if ( ImGui::Button(loc(TXT_rename)) )
-            {
-                is_renaming = true;
-            }
-            ImGui::Unindent();
-        }
-        else if ( is_renaming ) {
-            if (ImGui::InputText("##rename",
-                                  milton->canvas->working_layer->name,
-                                  13,
-                                  //MAX_LAYER_NAME_LEN,
-                                  ImGuiInputTextFlags_EnterReturnsTrue
-                                  //,ImGuiInputTextFlags flags = 0, ImGuiTextEditCallback callback = NULL, void* user_data = NULL
-                                 )) {
-                is_renaming = false;
-            }
-            ImGui::SameLine();
-            if ( ImGui::Button(loc(TXT_ok)) )
-            {
-                is_renaming = false;
-            }
-        }
         ImGui::Text(loc(TXT_move));
 
         Layer* a = NULL;


### PR DESCRIPTION
I've implemented double click layer renaming. Several things that aren't great:

- you can cancel/confirm the name change by either clicking on a different layer or by pressing Enter. What I think it needs is ability to cancel/confirm by clicking LMB anywhere.
- two static variables have been added. Not necessarily a good idea. Is there a better place to store the state?

It's not ready for merging but just wanted to suggest it and get your take on it @serge-rgb .