### PR TITLE
Fix: set force_next_frame to false at the end of the frame.

### DIFF
--- a/src/sdl_milton.cc
+++ b/src/sdl_milton.cc
@@ -344,6 +344,10 @@ sdl_event_loop(Milton* milton, PlatformState* platform)
                     if ( event.button.button == SDL_BUTTON_MIDDLE ) {
                         platform->is_middle_button_down = false;
                     }
+                    if ( ImGui::GetIO().WantCaptureMouse ) {
+                        // NOTE(ameen): button-click events that cause UI changes have 1 frame delay to update.
+                        platform->force_next_frame = true;
+                    }
                     pointer_up = true;
                     milton_input.flags |= MiltonInputFlags_CLICKUP;
                     milton_input.flags |= MiltonInputFlags_END_STROKE;
@@ -959,6 +963,9 @@ milton_main(bool is_fullscreen, char* file_to_open)
         // IMGUI events might update until the frame after they are created.
         if ( !platform.force_next_frame ) {
             SDL_WaitEvent(NULL);
+        }
+        else {
+            platform.force_next_frame = false;
         }
     }
 


### PR DESCRIPTION
I noticed after certain events (clicking on the GUI, using keyboard shortcuts) that CPU utilization for Milton is increased from `< 1.0%` to `6-7%`.

I debugged the issue and I found that `platform->force_next_frame` is never set to false anywhere in the code. Once it's set to true it will stay always true.