### PR TITLE
Fix: prevent mlt_file_path memory from being deinitialized.

### DIFF
--- a/src/sdl_milton.cc
+++ b/src/sdl_milton.cc
@@ -666,23 +666,22 @@ milton_main(bool is_fullscreen, char* file_to_open)
     platform.ui_scale = platform_ui_scale(&platform);
     milton_log("UI scale is %f\n", platform.ui_scale);
     // Initialize milton
-    {
-        PATH_CHAR* file_to_open_ = NULL;
-        PATH_CHAR buffer[MAX_PATH] = {};
+    PATH_CHAR* file_to_open_ = NULL;
+    PATH_CHAR buffer[MAX_PATH] = {};
 
-        if ( file_to_open ) {
-            file_to_open_ = (PATH_CHAR*)buffer;
-        }
-
-        str_to_path_char(file_to_open, (PATH_CHAR*)file_to_open_, MAX_PATH*sizeof(*file_to_open_));
-
-        milton_init(milton, platform.width, platform.height, platform.ui_scale, (PATH_CHAR*)file_to_open_);
-        milton->platform = &platform;
-        milton->gui->menu_visible = true;
-        if ( is_fullscreen ) {
-            milton->gui->menu_visible = false;
-        }
+    if ( file_to_open ) {
+        file_to_open_ = (PATH_CHAR*)buffer;
     }
+
+    str_to_path_char(file_to_open, (PATH_CHAR*)file_to_open_, MAX_PATH*sizeof(*file_to_open_));
+
+    milton_init(milton, platform.width, platform.height, platform.ui_scale, (PATH_CHAR*)file_to_open_);
+    milton->platform = &platform;
+    milton->gui->menu_visible = true;
+    if ( is_fullscreen ) {
+        milton->gui->menu_visible = false;
+    }
+
     milton_resize_and_pan(milton, {}, {platform.width, platform.height});
 
     platform.window_id = SDL_GetWindowID(window);


### PR DESCRIPTION
In release mode, the file path buffer `buffer` is getting reused after the scope is closed by other variables causing the `mlt_file_path` to become corrupted.

You can reproduce this by passing the `.mlt` file path on the command line or by double-clicking the file. You will see the file name corrupted in the menu bar at the top and new save files appear in the current directory with random names.

The simplest solution is to just remove the scope.