### PR TITLE
Fix #137: Remember GUI settings

### DIFF
--- a/src/gui.cc
+++ b/src/gui.cc
@@ -708,8 +708,8 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform,  Milton* milton)
         /* ImGuiSetCond_Once          = 1 << 1, // Only set the variable on the first call per runtime session */
         /* ImGuiSetCond_FirstUseEver */
 
-        const f32 brush_window_width = milton->gui->scale * 290;
-        const f32 brush_window_height = milton->gui->scale * 180;
+        const f32 brush_window_width = milton->gui->scale * 300;
+        const f32 brush_window_height = milton->gui->scale * 230;
 
         ImGui::SetNextWindowPos(ImVec2(milton->gui->scale * 10, milton->gui->scale * 10 + (float)pbounds.bottom), ImGuiSetCond_FirstUseEver);
         ImGui::SetNextWindowSize({brush_window_width, brush_window_height}, ImGuiSetCond_FirstUseEver);  // We don't want to set it *every* time, the user might have preferences

--- a/src/localization.cc
+++ b/src/localization.cc
@@ -111,6 +111,7 @@ init_localization()
         EN(TXT_enabled, "Enabled");
         EN(TXT_default_will_be_cleared, "The default canvas will be cleared. Save it?");
         EN(TXT_reset_view_at_origin, "Reset view at origin");
+        EN(TXT_reset_GUI, "Reset GUI layout (tool windows)");
         EN(TXT_size_relative_to_canvas, "Size relative to canvas");
 
         EN(TXT_Action_DECREASE_BRUSH_SIZE, "Decrease brush size");

--- a/src/localization.h
+++ b/src/localization.h
@@ -94,6 +94,7 @@ enum Texts
     TXT_enabled,
     TXT_default_will_be_cleared,
     TXT_reset_view_at_origin,
+    TXT_reset_GUI,
     TXT_size_relative_to_canvas,
 
     // Actions

--- a/src/persist.h
+++ b/src/persist.h
@@ -14,9 +14,9 @@ struct MiltonPersist
     PATH_CHAR*  mlt_file_path;
     u32         mlt_binary_version;
     WallTime    last_save_time;
-    i64         last_save_stroke_count;  // This is a workaround to MoveFileEx failing occasionally, particularaly when
+    i64         last_save_stroke_count; // This is a workaround to MoveFileEx failing occasionally, particularly
                                         // when the mlt file gets large.
-                                        // Check that all the strokes are saved at quit time in case that
+                                        // Check that all the strokes are saved at quit time in case
                                         // the last MoveFileEx failed.
     float target_MB_per_sec;
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -152,9 +152,20 @@ struct PlatformSettings
     // Store the window size at the time of quitting.
     i32 width;
     i32 height;
+
     // Last opened file.
     PATH_CHAR last_mlt_file[MAX_PATH];
 
+    // GUI settings.
+    i32 brush_window_left;
+    i32 brush_window_top;
+    i32 brush_window_width;
+    i32 brush_window_height;
+
+    i32 layer_window_left;
+    i32 layer_window_top;
+    i32 layer_window_width;
+    i32 layer_window_height;
 };
 
 // Defined in platform_windows.cc

--- a/src/sdl_milton.cc
+++ b/src/sdl_milton.cc
@@ -886,7 +886,7 @@ milton_main(bool is_fullscreen, char* file_to_open)
             input_flags |= MiltonInputFlags_IMGUI_GRABBED_INPUT;
         }
 
-        milton_imgui_tick(&milton_input, &platform, milton);
+        milton_imgui_tick(&milton_input, &platform, milton, &prefs);
 
         // Clear pan delta if we are zooming
         if ( milton_input.scale != 0 ) {
@@ -966,17 +966,13 @@ milton_main(bool is_fullscreen, char* file_to_open)
 
     arena_free(&milton->root_arena);
 
-    if(!is_fullscreen) {
-        bool save_prefs = prefs.width != platform.width || prefs.height != platform.height;
-        if ( save_prefs ) {
-            v2l size =  { platform.width,platform.height };
-            platform_pixel_to_point(&platform, &size);
+    // Save preferences.
+    v2l size =  { platform.width,platform.height };
+    platform_pixel_to_point(&platform, &size);
 
-            prefs.width  = size.w;
-            prefs.height = size.h;
-            platform_settings_save(&prefs);
-        }
-    }
+    prefs.width  = size.w;
+    prefs.height = size.h;
+    platform_settings_save(&prefs);
 
     SDL_Quit();
 


### PR DESCRIPTION
First let me say what a nice tool you created here! I like to have my monitor rotated 90° and then put my tool windows up top. That is why I created issue #137. I did not want to have to move the windows again every day :-)

Your code base is pretty nice to work with, I have some changes coming up soon but I wanted to start small with this one. I used 4 spaces instead of tabs and made sure to follow your general coding style (snake_case, spaces in the if braces, etc.) so I hope you can merge this without much hassle. If you have anything else that you would like me to fix first, please let me know :-)