### PR TITLE
Fix #142 allow ESC for keyboard shortcut

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -71,7 +71,7 @@ set_default_bindings(MiltonBindings* bs)
     binding(bs, Modifier_NONE, 'i', Action_MODE_EYEDROPPER);
     binding(bs, Modifier_NONE, 'l', Action_MODE_PRIMITIVE);
     binding(bs, Modifier_NONE, Binding::F1, Action_HELP);
-    binding(bs, Modifier_NONE, '\t', Action_TOGGLE_GUI);
+    binding(bs, Modifier_NONE, Binding::TAB, Action_TOGGLE_GUI);
 
     binding(bs, Modifier_NONE, '1', Action_SET_BRUSH_ALPHA_10);
     binding(bs, Modifier_NONE, '2', Action_SET_BRUSH_ALPHA_20);

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -80,7 +80,8 @@ struct Binding
    enum Key
    {
       UNBOUND = 0,
-      ESC = -1,
+      TAB = '\t',
+      ESC = 27,
 
       F1 = -2,
       F2 = -3,

--- a/src/sdl_milton.cc
+++ b/src/sdl_milton.cc
@@ -77,17 +77,15 @@ shortcut_handle_key(Milton* milton, PlatformState* platform, SDL_Event* event, M
         }
         else {
             switch (k) {
-                case SDLK_TAB: { active_key = SDLK_TAB;  } break;
-                case SDLK_ESCAPE: { active_key = Binding::ESC; } break;
-                case SDLK_F1: { active_key = Binding::F1; } break;
-                case SDLK_F2: { active_key = Binding::F2; } break;
-                case SDLK_F3: { active_key = Binding::F3; } break;
-                case SDLK_F4: { active_key = Binding::F4; } break;
-                case SDLK_F5: { active_key = Binding::F5; } break;
-                case SDLK_F6: { active_key = Binding::F6; } break;
-                case SDLK_F7: { active_key = Binding::F7; } break;
-                case SDLK_F8: { active_key = Binding::F8; } break;
-                case SDLK_F9: { active_key = Binding::F9; } break;
+                case SDLK_F1:  { active_key = Binding::F1;  } break;
+                case SDLK_F2:  { active_key = Binding::F2;  } break;
+                case SDLK_F3:  { active_key = Binding::F3;  } break;
+                case SDLK_F4:  { active_key = Binding::F4;  } break;
+                case SDLK_F5:  { active_key = Binding::F5;  } break;
+                case SDLK_F6:  { active_key = Binding::F6;  } break;
+                case SDLK_F7:  { active_key = Binding::F7;  } break;
+                case SDLK_F8:  { active_key = Binding::F8;  } break;
+                case SDLK_F9:  { active_key = Binding::F9;  } break;
                 case SDLK_F10: { active_key = Binding::F10; } break;
                 case SDLK_F11: { active_key = Binding::F11; } break;
                 case SDLK_F12: { active_key = Binding::F12; } break;


### PR DESCRIPTION
SDLK_TAB=9 and SDLK_ESCAPE=27 are in the ASCII range so they are not
treated differently in the shortcut handler code anymore. This fixes
using ESC in a shortcut. Currently ESC is not used anywhere, that is
why the bug was not found before.