### PR TITLE
 Fix #140 add Cancel option to new canvas dialog

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -126,23 +126,25 @@ binding_dispatch_action(BindableAction a, MiltonInput* input, Milton* milton, v2
             milton_try_quit(milton);
         } break;
         case Action_NEW: {
-            b32 save_file = false;
+            i32 save_file = ANSWER_NO;
             if ( layer::count_strokes(milton->canvas->root_layer) > 0 ) {
                 if ( milton->flags & MiltonStateFlags_DEFAULT_CANVAS ) {
-                    save_file = platform_dialog_yesno(default_will_be_lost, "Save?");
+                    save_file = platform_dialog_yesnocancel(default_will_be_lost, "Save?");
                 }
             }
-            if ( save_file ) {
+            if ( save_file == ANSWER_CANCEL )
+                break;
+            if ( save_file == ANSWER_YES ) {
                 PATH_CHAR* name = platform_save_dialog(FileKind_MILTON_CANVAS);
-                if ( name ) {
-                    milton_log("Saving to %s\n", name);
-                    milton_set_canvas_file(milton, name);
-                    milton_save(milton);
-                    b32 del = platform_delete_file_at_config(TO_PATH_STR("MiltonPersist.mlt"), DeleteErrorTolerance_OK_NOT_EXIST);
-                    if ( del == false ) {
-                        platform_dialog("Could not delete contents. The work will be still be there even though you saved it to a file.",
-                            "Info");
-                    }
+                if ( !name ) // save dialog was cancelled
+                    break;
+                milton_log("Saving to %s\n", name);
+                milton_set_canvas_file(milton, name);
+                milton_save(milton);
+                b32 del = platform_delete_file_at_config(TO_PATH_STR("MiltonPersist.mlt"), DeleteErrorTolerance_OK_NOT_EXIST);
+                if ( del == false ) {
+                    platform_dialog("Could not delete contents. The work will be still be there even though you saved it to a file.",
+                        "Info");
                 }
             }
             milton_reset_canvas_and_set_default(milton);

--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -126,15 +126,15 @@ binding_dispatch_action(BindableAction a, MiltonInput* input, Milton* milton, v2
             milton_try_quit(milton);
         } break;
         case Action_NEW: {
-            i32 save_file = ANSWER_NO;
+            YesNoCancelAnswer save_file = YesNoCancelAnswer::No;
             if ( layer::count_strokes(milton->canvas->root_layer) > 0 ) {
                 if ( milton->flags & MiltonStateFlags_DEFAULT_CANVAS ) {
                     save_file = platform_dialog_yesnocancel(default_will_be_lost, "Save?");
                 }
             }
-            if ( save_file == ANSWER_CANCEL )
+            if ( save_file == YesNoCancelAnswer::Cancel )
                 break;
-            if ( save_file == ANSWER_YES ) {
+            if ( save_file == YesNoCancelAnswer::Yes ) {
                 PATH_CHAR* name = platform_save_dialog(FileKind_MILTON_CANVAS);
                 if ( !name ) // save dialog was cancelled
                     break;

--- a/src/platform.h
+++ b/src/platform.h
@@ -179,15 +179,13 @@ PATH_CHAR*   platform_save_dialog(FileKind kind);
 void    platform_dialog(char* info, char* title);
 b32     platform_dialog_yesno(char* info, char* title);
 
-// platform_dialog_yesnocancel returns
-//  1 for Yes
-//  0 for No
-// -1 for Cancel
-// but you can use the ANSWER_... constants.
-i32 platform_dialog_yesnocancel(char* info, char* title);
-const i32 ANSWER_YES    =  1;
-const i32 ANSWER_NO     =  0;
-const i32 ANSWER_CANCEL = -1;
+enum YesNoCancelAnswer
+{
+    Yes,
+    No,
+    Cancel
+};
+YesNoCancelAnswer platform_dialog_yesnocancel(char* info, char* title);
 
 void*   platform_get_gl_proc(char* name);
 void    platform_load_gl_func_pointers();

--- a/src/platform.h
+++ b/src/platform.h
@@ -171,12 +171,23 @@ struct PlatformSettings
 // Defined in platform_windows.cc
 FILE*   platform_fopen(const PATH_CHAR* fname, const PATH_CHAR* mode);
 
-// Returns a 0-terminated string with the full path of the target file. NULL if error.
+// Returns a 0-terminated string with the full path of the target file.
+// If the user cancels the operation it returns NULL.
 PATH_CHAR*   platform_open_dialog(FileKind kind);
 PATH_CHAR*   platform_save_dialog(FileKind kind);
 
 void    platform_dialog(char* info, char* title);
 b32     platform_dialog_yesno(char* info, char* title);
+
+// platform_dialog_yesnocancel returns
+//  1 for Yes
+//  0 for No
+// -1 for Cancel
+// but you can use the ANSWER_... constants.
+i32 platform_dialog_yesnocancel(char* info, char* title);
+const i32 ANSWER_YES    =  1;
+const i32 ANSWER_NO     =  0;
+const i32 ANSWER_CANCEL = -1;
 
 void*   platform_get_gl_proc(char* name);
 void    platform_load_gl_func_pointers();

--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -147,7 +147,7 @@ platform_dialog_yesno(char* info, char* title)
     return true;
 }
 
-i32
+YesNoCancelAnswer
 platform_dialog_yesnocancel(char* info, char* title);
 {
     platform_cursor_show();
@@ -163,10 +163,10 @@ platform_dialog_yesnocancel(char* info, char* title);
     gint answer = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
     if ( answer == GTK_RESPONSE_YES )
-        return ANSWER_YES;
+        return YesNoCancelAnswer::Yes;
     if ( answer == GTK_RESPONSE_NO )
-        return ANSWER_NO;
-    return ANSWER_CANCEL;
+        return YesNoCancelAnswer::No;
+    return YesNoCancelAnswer::Cancel;
 }
 
 void

--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -147,6 +147,28 @@ platform_dialog_yesno(char* info, char* title)
     return true;
 }
 
+i32
+platform_dialog_yesnocancel(char* info, char* title);
+{
+    platform_cursor_show();
+    GtkWidget *dialog = gtk_message_dialog_new(
+            NULL,
+            (GtkDialogFlags)0,
+            GTK_MESSAGE_QUESTION,
+            GTK_BUTTONS_OK_CANCEL,
+            "%s",
+            info
+            );
+    gtk_window_set_title(GTK_WINDOW(dialog), title);
+    gint answer = gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+    if ( answer == GTK_RESPONSE_YES )
+        return ANSWER_YES;
+    if ( answer == GTK_RESPONSE_NO )
+        return ANSWER_NO;
+    return ANSWER_CANCEL;
+}
+
 void
 platform_fname_at_config(PATH_CHAR* fname, size_t len)
 {

--- a/src/platform_windows.cc
+++ b/src/platform_windows.cc
@@ -511,6 +511,22 @@ platform_dialog_yesno(char* info, char* title)
     return yes == IDYES;
 }
 
+i32
+platform_dialog_yesnocancel(char* info, char* title)
+{
+    platform_cursor_show();
+    i32 answer = MessageBoxA(NULL, //_In_opt_ HWND    hWnd,
+                             (LPCSTR)info, // _In_opt_ LPCTSTR lpText,
+                             (LPCSTR)title,// _In_opt_ LPCTSTR lpCaption,
+                             MB_YESNOCANCEL//_In_     UINT    uType
+                            );
+    if ( answer == IDYES )
+        return ANSWER_YES;
+    if ( answer == IDNO )
+        return ANSWER_NO;
+    return ANSWER_CANCEL;
+}
+
 void
 platform_dialog(char* info, char* title)
 {

--- a/src/platform_windows.cc
+++ b/src/platform_windows.cc
@@ -511,7 +511,7 @@ platform_dialog_yesno(char* info, char* title)
     return yes == IDYES;
 }
 
-i32
+YesNoCancelAnswer
 platform_dialog_yesnocancel(char* info, char* title)
 {
     platform_cursor_show();
@@ -521,10 +521,10 @@ platform_dialog_yesnocancel(char* info, char* title)
                              MB_YESNOCANCEL//_In_     UINT    uType
                             );
     if ( answer == IDYES )
-        return ANSWER_YES;
+        return YesNoCancelAnswer::Yes;
     if ( answer == IDNO )
-        return ANSWER_NO;
-    return ANSWER_CANCEL;
+        return YesNoCancelAnswer::No;
+    return YesNoCancelAnswer::Cancel;
 }
 
 void


### PR DESCRIPTION
I am re-creating this pull request on its own branch. Github was kind enough to pretend that I had created a new fork when really it was the old one. This means I accidentally put two PRs in the same repo's master branch... thanks Github! Anyway, here is the original PR text:

When creating a new canvas the old progress might be lost. The user is
queried with a dialog to save their progress. A new option "cancel" is
now available which lets you continue working on the current canvas
instead of creating a new one.

Also, cancelling the save dialog in case you answer "yes" to saving
your progress will also get you back to the current canvas instead of
creating a new one.

IMPORTANT NOTE: I did not test the Linux version with the GTK dialog. I have no Linux dev environment currently set up so I created that all by example of the other dialog and with the help of online documentation. Still someone has to test it before merging this PR.