### PR TITLE
Format tabs as spaces

### DIFF
--- a/src/gui.cc
+++ b/src/gui.cc
@@ -778,15 +778,15 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform,  Milton* milton, 
                 char cancel[64] = {};
                 snprintf(cancel, array_count(cancel), "%s##%d", loc(TXT_cancel), i);
 
-    			if (ImGui::Button(ok)) {
-    				milton_settings_save(milton->settings);
-    				show_settings = false;
-    			}
-    			ImGui::SameLine();
-    			if (ImGui::Button(cancel)) {
-    				show_settings = false;
+                if (ImGui::Button(ok)) {
+                    milton_settings_save(milton->settings);
+                    show_settings = false;
+                }
+                ImGui::SameLine();
+                if (ImGui::Button(cancel)) {
+                    show_settings = false;
                     *milton->settings = *gui->original_settings;
-    			}
+                }
             };
 
             ImGui::SetNextWindowSize(ImVec2(ui_scale*400, ui_scale*400),
@@ -807,11 +807,11 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform,  Milton* milton, 
                     milton->settings->background_color = milton->view->background_color;
                 }
 
-				const float peek_range = 20;
-				int peek_out_percent = 100 * (milton->settings->peek_out_increment / peek_range);
+                const float peek_range = 20;
+                int peek_out_percent = 100 * (milton->settings->peek_out_increment / peek_range);
                 if (ImGui::SliderInt(loc(TXT_peek_out_increment_percent), &peek_out_percent, 0, 100)) {
-					milton->settings->peek_out_increment = (peek_out_percent / 100.0f) * peek_range;
-				}
+                    milton->settings->peek_out_increment = (peek_out_percent / 100.0f) * peek_range;
+                }
 
                 ImGui::Separator();
 
@@ -827,7 +827,7 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform,  Milton* milton, 
                     snprintf(alt_lbl, array_count(alt_lbl), "alt##%d", (int)i);
 
                     char win_lbl[64] = {};
-					snprintf(win_lbl, array_count(win_lbl), "win##%d", (int)i);
+                    snprintf(win_lbl, array_count(win_lbl), "win##%d", (int)i);
 
 
                     ImGui::CheckboxFlags(control_lbl, (unsigned int*)&b->modifiers, Modifier_CTRL);
@@ -851,7 +851,7 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform,  Milton* milton, 
 
                 ImGui::SetCursorPosY( ImGui::GetCursorPosY() + ui_scale*80 );
 
-				ok_cancel(2);
+                ok_cancel(2);
 
             } ImGui::End();
         }

--- a/src/milton.cc
+++ b/src/milton.cc
@@ -33,7 +33,7 @@ init_view(CanvasView* view, v3f background_color, i32 width, i32 height)
 
     *view = CanvasView{};
 
-	view->size = sizeof(CanvasView);
+    view->size = sizeof(CanvasView);
     view->background_color  = background_color;
     view->screen_size       = size;
     view->zoom_center       = size / 2;
@@ -872,7 +872,7 @@ milton_save_thread(void* state_)
                     milton->save_flag = SaveEnum_WAITING;
                 }
             }
-			wait_begin_us = perf_counter();
+            wait_begin_us = perf_counter();
         }
         SDL_UnlockMutex(milton->save_mutex);
 

--- a/src/persist.cc
+++ b/src/persist.cc
@@ -361,12 +361,12 @@ milton_load(Milton* milton)
                     READ(milton->brushes + i, sizeof(BrushPreV7), 1, fd);
                 }
             }
-			else if (milton_binary_version < 8) {
+            else if (milton_binary_version < 8) {
                 for (int i = 0; i < num_brushes; ++i) {
                     milton->brushes[i] = default_brush();
                     READ(milton->brushes + i, sizeof(BrushPreV8), 1, fd);
                 }
-			}
+            }
             else {
                 if (!read_brushes(milton->brushes, num_brushes, fd)) {
                     ok = false;

--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -304,7 +304,7 @@ platform_get_walltime()
 }
 
 void*
-platform_get_gl_proc(char* name) 
+platform_get_gl_proc(char* name)
 {
     return glXGetProcAddressARB((GLubyte*)name);
 }

--- a/src/platform_unix.cc
+++ b/src/platform_unix.cc
@@ -136,7 +136,7 @@ platform_monitor_refresh_hz()
     return hz;
 }
 
-int 
+int
 platform_titlebar_height(PlatformState* p)
 {
     return 20; // TODO: implement on mac and linux

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -135,7 +135,7 @@ struct RenderBackend
     // See MAX_DEPTH_VALUE
     i32 stroke_z;
 
-	// TODO: Re-enable these?
+    // TODO: Re-enable these?
     // Cached values for stroke rendering uniforms.
     // v4f current_color;
     // float current_radius;


### PR DESCRIPTION
To have a consistent code base, all tabs are now converted to 4 spaces.