### PR TITLE
Add Yes/No/Cancel Dialog For MacOS

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -126,15 +126,15 @@ binding_dispatch_action(BindableAction a, MiltonInput* input, Milton* milton, v2
             milton_try_quit(milton);
         } break;
         case Action_NEW: {
-            YesNoCancelAnswer save_file = YesNoCancelAnswer::NO;
+            YesNoCancelAnswer save_file = YesNoCancelAnswer::NO_;
             if ( layer::count_strokes(milton->canvas->root_layer) > 0 ) {
                 if ( milton->flags & MiltonStateFlags_DEFAULT_CANVAS ) {
                     save_file = platform_dialog_yesnocancel(default_will_be_lost, "Save?");
                 }
             }
-            if ( save_file == YesNoCancelAnswer::CANCEL )
+            if ( save_file == YesNoCancelAnswer::CANCEL_ )
                 break;
-            if ( save_file == YesNoCancelAnswer::YES ) {
+            if ( save_file == YesNoCancelAnswer::YES_ ) {
                 PATH_CHAR* name = platform_save_dialog(FileKind_MILTON_CANVAS);
                 if ( !name ) // save dialog was cancelled
                     break;

--- a/src/platform.h
+++ b/src/platform.h
@@ -179,11 +179,15 @@ PATH_CHAR*   platform_save_dialog(FileKind kind);
 void    platform_dialog(char* info, char* title);
 b32     platform_dialog_yesno(char* info, char* title);
 
+// NOTE: These constants end with an underscore in order to prevent issues on
+// macOS where the Objective-C headers define macros `YES` and `NO` as part of
+// the `BOOL` type. Removing the underscores and compiling on macOS causes the
+// compiler to attempt macro expansion on these names resulting in errors.
 enum YesNoCancelAnswer
 {
-    YES,
-    NO,
-    CANCEL,
+    YES_,
+    NO_,
+    CANCEL_,
 };
 YesNoCancelAnswer platform_dialog_yesnocancel(char* info, char* title);
 

--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -175,10 +175,10 @@ platform_dialog_yesnocancel(char* info, char* title)
     gint answer = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
     if ( answer == GTK_RESPONSE_YES )
-        return YesNoCancelAnswer::YES;
+        return YesNoCancelAnswer::YES_;
     if ( answer == GTK_RESPONSE_NO )
-        return YesNoCancelAnswer::NO;
-    return YesNoCancelAnswer::CANCEL;
+        return YesNoCancelAnswer::NO_;
+    return YesNoCancelAnswer::CANCEL_;
 }
 
 void

--- a/src/platform_mac.mm
+++ b/src/platform_mac.mm
@@ -122,6 +122,25 @@ platform_dialog_yesno_mac(char* info, char* title)
     }
 }
 
+YesNoCancelAnswer
+platform_dialog_yesnocancel(char* info, char* title)
+{
+    @autoreleasepool {
+        NSAlert *alert = mac_alert(info, title);
+        [alert addButtonWithTitle:NSLocalizedString(@"Yes", nil)];
+        [alert addButtonWithTitle:NSLocalizedString(@"No", nil)];
+        [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
+        NSModalResponse result = [alert runModal];
+        if (result == NSAlertFirstButtonReturn) {
+          return YesNoCancelAnswer::YES_;
+        }
+        else if (result == NSAlertSecondButtonReturn) {
+          return YesNoCancelAnswer::NO_;
+        }
+        return YesNoCancelAnswer::CANCEL_;
+    }
+}
+
 char*
 platform_open_dialog_mac(FileKind kind)
 {

--- a/src/platform_windows.cc
+++ b/src/platform_windows.cc
@@ -521,10 +521,10 @@ platform_dialog_yesnocancel(char* info, char* title)
                              MB_YESNOCANCEL//_In_     UINT    uType
                             );
     if ( answer == IDYES )
-        return YesNoCancelAnswer::YES;
+        return YesNoCancelAnswer::YES_;
     if ( answer == IDNO )
-        return YesNoCancelAnswer::NO;
-    return YesNoCancelAnswer::CANCEL;
+        return YesNoCancelAnswer::NO_;
+    return YesNoCancelAnswer::CANCEL_;
 }
 
 void


### PR DESCRIPTION
**DESCRIPTION**
Closes #149 

On macOS the file `objc/objc.h` defines macros `YES` and `NO` as part of the Objective-C `BOOL` type definition. Milton also defines its own `YesNoCancelAnswer` enumeration type containing values `YES` and `NO`.

On macOS this causes a conflict where the compiler attempts macro expansion on the definitions of `YesNoCancelAnswer::YES` and `YesNoCancelAnswer::NO`. This leads to compilation failure.

To fix this failure, this change renames the constants of `YesNoCancelAnswer` from `YES` to `YES_`, `NO` to `NO_`, and for consistency from `CANCEL` to `CANCEL_`. All occurrences of the previous constants are replaced.

In addition, this change adds the required function `platform_dialog_yesnocancel` to `src/platform_mac.mm`. This displays a Yes/No/Cancel dialog box on macOS and returns the users response.

**TESTED**
- [X] Compiles on macOS Mojave (v10.14.6) without error.