### PR TITLE
Drag based zoom

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -89,6 +89,7 @@ set_default_bindings(MiltonBindings* bs)
     binding_with_release(bs, Modifier_NONE, '`', Action_PEEK_OUT, ActionRelease_PEEK_OUT);
     binding_with_release(bs, Modifier_SHIFT, Binding::UNBOUND, Action_DRAG_BRUSH_SIZE, ActionRelease_DRAG_BRUSH_SIZE);
     binding_with_release(bs, Modifier_ALT, Binding::UNBOUND, Action_TRANSFORM, ActionRelease_TRANSFORM);
+    binding_with_release(bs, Modifier_CTRL, Binding::UNBOUND, Action_DRAG_ZOOM, ActionRelease_DRAG_ZOOM);
 
     #if MILTON_ENABLE_PROFILING
     binding(bs, Modifier_CTRL, '`', Action_TOGGLE_DEBUG_WINDOW);
@@ -267,6 +268,12 @@ binding_dispatch_action(BindableAction a, MiltonInput* input, Milton* milton, v2
         } break;
         case ActionRelease_DRAG_BRUSH_SIZE: {
             drag_brush_size_stop(milton);
+        } break;
+        case Action_DRAG_ZOOM: {
+            drag_zoom_start(milton, pointer);
+        } break;
+        case ActionRelease_DRAG_ZOOM: {
+            drag_zoom_stop(milton);
         } break;
         case Action_TRANSFORM: {
             transform_start(milton, pointer);

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -42,6 +42,7 @@ enum BindableAction
     Action_HELP,
     Action_PEEK_OUT,
     Action_DRAG_BRUSH_SIZE,
+    Action_DRAG_ZOOM,
     Action_TRANSFORM,
 
     #if MILTON_ENABLE_PROFILING
@@ -54,6 +55,7 @@ enum BindableAction
     // Press-and-release actions.
     ActionRelease_PEEK_OUT,
     ActionRelease_DRAG_BRUSH_SIZE,
+    ActionRelease_DRAG_ZOOM,
     ActionRelease_TRANSFORM,
 
     Action_COUNT_WITH_RELEASE,

--- a/src/localization.cc
+++ b/src/localization.cc
@@ -151,6 +151,7 @@ init_localization()
         EN(TXT_Action_HELP, "Help");
         EN(TXT_Action_PEEK_OUT, "Peek out");
         EN(TXT_Action_DRAG_BRUSH_SIZE, "Drag to change brush size");
+        EN(TXT_Action_DRAG_ZOOM, "Drag to zoom in/out");
         EN(TXT_Action_TRANSFORM, "Rotate");
     #if MILTON_ENABLE_PROFILING
         EN(TXT_Action_TOGGLE_DEBUG_WINDOW, "Toggle debug window");

--- a/src/localization.h
+++ b/src/localization.h
@@ -136,6 +136,7 @@ enum Texts
     TXT_Action_HELP,
     TXT_Action_PEEK_OUT,
     TXT_Action_DRAG_BRUSH_SIZE,
+    TXT_Action_DRAG_ZOOM,
     TXT_Action_TRANSFORM,
 
 #if MILTON_ENABLE_PROFILING

--- a/src/milton.cc
+++ b/src/milton.cc
@@ -160,6 +160,7 @@ mode_is_for_drawing(MiltonMode mode)
     b32 result = mode == MiltonMode::PEN ||
             mode == MiltonMode::ERASER ||
             mode == MiltonMode::DRAG_BRUSH_SIZE ||
+            mode == MiltonMode::DRAG_ZOOM ||
             mode_is_for_primitives(mode);
     return result;
 }
@@ -655,6 +656,7 @@ milton_init(Milton* milton, i32 width, i32 height, f32 ui_scale, PATH_CHAR* file
     milton->eyedropper = arena_alloc_elem(&milton->root_arena, Eyedropper);
     milton->persist = arena_alloc_elem(&milton->root_arena, MiltonPersist);
     milton->drag_brush = arena_alloc_elem(&milton->root_arena, MiltonDragBrush);
+    milton->drag_zoom = arena_alloc_elem(&milton->root_arena, MiltonDragZoom);
     milton->transform = arena_alloc_elem(&milton->root_arena, TransformMode);
 
     milton->persist->target_MB_per_sec = 0.2f;
@@ -1288,6 +1290,46 @@ drag_brush_size_tick(Milton* milton, MiltonInput const* input)
 }
 
 void
+drag_zoom_start(Milton* milton, v2i pointer)
+{
+    if ( milton->current_mode != MiltonMode::DRAG_ZOOM &&
+         current_mode_is_for_drawing(milton) ) {
+        i64 size = milton->view->scale;
+        milton->drag_zoom->start_point = platform_cursor_get_position(milton->platform);
+        milton->drag_zoom->start_size = size;
+        milton->drag_zoom->new_zoom_center = milton->platform->pointer;
+        milton_enter_mode(milton, MiltonMode::DRAG_ZOOM);
+    }
+}
+
+void
+drag_zoom_stop(Milton* milton)
+{
+    if (milton->current_mode == MiltonMode::DRAG_ZOOM) {
+        v2i point = milton->drag_zoom->start_point;
+        platform_cursor_set_position(milton->platform, point);
+        milton_leave_mode(milton);
+    }
+}
+
+static void
+drag_zoom_tick(Milton* milton, MiltonInput const* input)
+{
+    MiltonDragZoom* drag = milton->drag_zoom;
+    f32 drag_factor = 0.5f;
+    v2i mouse = platform_cursor_get_position(milton->platform);
+
+    i64 new_size = drag->start_size + drag_factor * -(mouse.x - mouse.y - drag->start_point.x + drag->start_point.y);
+     if ( new_size < MINIMUM_SCALE )
+         new_size = MINIMUM_SCALE;
+     if ( new_size > VIEW_SCALE_LIMIT )
+         new_size = VIEW_SCALE_LIMIT;
+    milton->view->scale = new_size;
+    milton_set_zoom_at_point(milton, drag->new_zoom_center);
+}
+
+
+void
 transform_start(Milton* milton, v2i pointer)
 {
     if (milton->current_mode != MiltonMode::TRANSFORM) {
@@ -1589,6 +1631,9 @@ milton_update_and_render(Milton* milton, MiltonInput const* input)
     }
     else if (milton->current_mode == MiltonMode::DRAG_BRUSH_SIZE) {
         drag_brush_size_tick(milton, input);
+    }
+    else if (milton->current_mode == MiltonMode::DRAG_ZOOM) {
+        drag_zoom_tick(milton, input);
     }
     else if (milton->current_mode == MiltonMode::TRANSFORM) {
         transform_tick(milton, input);

--- a/src/milton.cc
+++ b/src/milton.cc
@@ -1316,14 +1316,17 @@ static void
 drag_zoom_tick(Milton* milton, MiltonInput const* input)
 {
     MiltonDragZoom* drag = milton->drag_zoom;
-    f32 drag_factor = 0.5f;
-    v2i mouse = platform_cursor_get_position(milton->platform);
+    f32 drag_factor = 100.0f * ( static_cast<f32>(drag->start_size) / VIEW_SCALE_LIMIT );
+    i64 mouse_x = platform_cursor_get_position(milton->platform).x;
 
-    i64 new_size = drag->start_size + drag_factor * -(mouse.x - mouse.y - drag->start_point.x + drag->start_point.y);
+    i64 new_size = drag->start_size + drag_factor * -(mouse_x - drag->start_point.x );
+
+    
     if ( new_size < MINIMUM_SCALE )
         new_size = MINIMUM_SCALE;
     if ( new_size > VIEW_SCALE_LIMIT )
         new_size = VIEW_SCALE_LIMIT;
+    
     milton->view->scale = new_size;
     milton_set_zoom_at_point(milton, drag->new_zoom_center);
 }

--- a/src/milton.cc
+++ b/src/milton.cc
@@ -1320,10 +1320,10 @@ drag_zoom_tick(Milton* milton, MiltonInput const* input)
     v2i mouse = platform_cursor_get_position(milton->platform);
 
     i64 new_size = drag->start_size + drag_factor * -(mouse.x - mouse.y - drag->start_point.x + drag->start_point.y);
-     if ( new_size < MINIMUM_SCALE )
-         new_size = MINIMUM_SCALE;
-     if ( new_size > VIEW_SCALE_LIMIT )
-         new_size = VIEW_SCALE_LIMIT;
+    if ( new_size < MINIMUM_SCALE )
+        new_size = MINIMUM_SCALE;
+    if ( new_size > VIEW_SCALE_LIMIT )
+        new_size = VIEW_SCALE_LIMIT;
     milton->view->scale = new_size;
     milton_set_zoom_at_point(milton, drag->new_zoom_center);
 }

--- a/src/milton.h
+++ b/src/milton.h
@@ -37,6 +37,7 @@ enum class MiltonMode
     HISTORY,
     PEEK_OUT,
     DRAG_BRUSH_SIZE,
+    DRAG_ZOOM,
     TRANSFORM,  // Scale and rotate
 
     MODE_COUNT,
@@ -149,6 +150,13 @@ struct MiltonDragBrush
     v2i start_point;
 };
 
+struct MiltonDragZoom
+{
+    i64 start_size;
+    v2i start_point;
+    v2i new_zoom_center;
+};
+
 enum class TransformModeFSM
 {
     START,
@@ -220,6 +228,7 @@ struct Milton
     MiltonSettings* settings;  // User settings
     MiltonPersist* persist;
     MiltonDragBrush* drag_brush;
+    MiltonDragZoom* drag_zoom;
     PeekOut* peek_out;
     TransformMode* transform;
 
@@ -359,3 +368,6 @@ void transform_stop(Milton* milton);
 
 void drag_brush_size_start(Milton* milton, v2i pointer);
 void drag_brush_size_stop(Milton* milton);
+
+void drag_zoom_start(Milton* milton, v2i pointer);
+void drag_zoom_stop(Milton* milton);


### PR DESCRIPTION
I implemented DRAG_ZOOM based on how DRAG_BURSH_SIZE works. 

Click and drag up, down to zoom in and out. 

I noticed someone else had already contributed a PR doing the same in a different way but still, I like the way zooming in and out feels with this PR so maybe you want to take that part as a reference