### PR TITLE
Fix trivial source comment typos

### DIFF
--- a/src/easytab.h
+++ b/src/easytab.h
@@ -975,7 +975,7 @@ EasyTabResult EasyTab_Load_Ex(HWND Window,
     UINT DesiredPktRate = 200;
     {
         UINT MaxPktRate = 0;
-        // Get maxiumum rate (DVX_PKTRATE)
+        // Get maximum rate (DVX_PKTRATE)
         if (EasyTab->WTInfoA(WTI_DEVICES, DVC_PKTRATE, &MaxPktRate))
         {
             DesiredPktRate = min(DesiredPktRate, MaxPktRate);
@@ -1076,7 +1076,7 @@ EasyTabResult EasyTab_Load_Ex(HWND Window,
             return EASYTAB_WACOM_WIN32_ERROR;
         }
 
-        // Get tablet capabilites
+        // Get tablet capabilities
         {
             EasyTab->MaxPressure = Pressure.axMax;
             EasyTab->RangeX      = RangeX.axMax;
@@ -1177,7 +1177,7 @@ EasyTabResult EasyTab_HandleEvent(HWND Window, UINT Message, LPARAM LParam, WPAR
 
         }
         result = EASYTAB_OK;
-        // Alway clear the queue.
+        // Always clear the queue.
         EasyTab->WTPacketsGet(EasyTab->Context, EASYTAB_PACKETQUEUE_SIZE+1, NULL);
     }
     else if (Message == WM_ACTIVATE && EasyTab->Context)

--- a/src/platform_mac.mm
+++ b/src/platform_mac.mm
@@ -243,7 +243,7 @@ perf_counter()
     timespec tp;
     int res = clock_gettime(CLOCK_REALTIME, &tp);
 
-    // TODO: Check errno and provide more informations
+    // TODO: Check errno and provide more information
     if ( res ) {
         milton_log("Something went wrong with clock_gettime\n");
     }

--- a/src/platform_unix.h
+++ b/src/platform_unix.h
@@ -6,7 +6,7 @@
     #define _GNU_SOURCE  // To get MAP_ANONYMOUS on linux
     #endif
     #include <gtk/gtk.h>
-    #define __USE_MISC 1  // MAP_ANONYMOUS and MAP_NORESERVE dont' get defined without this
+    #define __USE_MISC 1  // MAP_ANONYMOUS and MAP_NORESERVE don't get defined without this
     #include <sys/mman.h>
     #undef __USE_MISC
     #include <unistd.h>

--- a/src/postproc.f.glsl
+++ b/src/postproc.f.glsl
@@ -57,7 +57,7 @@ main()
         //
         // Only used on the optimized 360 version of FXAA Console.
         // For everything but 360, just use the same input here as for texÏ.
-        // For 360, same texture, just alias with a 3nd sampler.
+        // For 360, same texture, just alias with a 3rd sampler.
         // This sampler needs to have an exponent bias of -2.
         u_canvas, // FxaaTex fxaaConsole360TexExpBiasNegTwo,
         //

--- a/src/sdl_milton.cc
+++ b/src/sdl_milton.cc
@@ -738,7 +738,7 @@ milton_main(bool is_fullscreen, char* file_to_open)
             fclose(fd);
         }
     }
-    // Initalize system cursors
+    // Initialize system cursors
     {
         platform.cursor_default   = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
         platform.cursor_hand      = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);


### PR DESCRIPTION
Found via `codespell -q 3 -S ./third_party -L apoints,inout`