### PR TITLE
Fix platform_windows broken since #190 extern "C" fix for platform_unix

### DIFF
--- a/src/platform_windows.h
+++ b/src/platform_windows.h
@@ -5,14 +5,14 @@
 
 #include "milton_configuration.h"
 
+extern "C"
+{
+
 #define getpid _getpid
 #define platform_milton_log win32_log
 #define platform_milton_log_args win32_log_args
 void win32_log(char *format, ...);
 void win32_log_args(char *format, va_list args);
-
-extern "C"
-{
 
     // -------------------------------  SHlObj.h
 #define CSIDL_DESKTOP                   0x0000        // <desktop>


### PR DESCRIPTION
win32_log and win32_log_args were not declared extern "C"
even though they were defined extern "C".

Without the fix, build.bat has the following errors:

```
src\platform_windows.cc(372): error C2732: linkage specification contradicts earlier specification for 'win32_log'
src\platform_windows.cc(371): note: see declaration of 'win32_log'
src\platform_windows.cc(383): error C2732: linkage specification contradicts earlier specification for 'win32_log_args'
src\platform_windows.cc(382): note: see declaration of 'win32_log_args'
```

Apologies, this was introduced by me when fixing Linux builds in #190.