### PR TITLE
Linux stylus buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,10 @@ src/shaders.gen.h
 
 # Deploy script
 OUTPUT
+
+# my stuff
+.ccls-cache
+src/.ccls-cache
+src/compile_commands.json
+setup_linux.sh
+nick

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(Milton)
 
 if(WIN32)

--- a/src/easytab.h
+++ b/src/easytab.h
@@ -801,7 +801,7 @@ EasyTabResult EasyTab_Load(Display* Disp, Window Win)
                     ProximityIn(EasyTab->Device, EasyTab->ProximityTypeIn, EventClassProximityIn);
                     ProximityOut(EasyTab->Device, EasyTab->ProximityTypeOut,EventClassProximityOut );
                     DeviceButtonPress(EasyTab->Device, EasyTab->ButtonTypePress, EventClassButtonPress);
-                    DeviceButtonPress(EasyTab->Device, EasyTab->ButtonTypeRelease, EventClassButtonRelease);
+                    DeviceButtonRelease(EasyTab->Device, EasyTab->ButtonTypeRelease, EventClassButtonRelease);
 
                     #define APPEND_EVENT_CLASS(EventClass) \
                         if (EventClass)                                                     \
@@ -813,6 +813,8 @@ EasyTabResult EasyTab_Load(Display* Disp, Window Win)
                     APPEND_EVENT_CLASS(EventClassMotion);
                     APPEND_EVENT_CLASS(EventClassProximityIn);
                     APPEND_EVENT_CLASS(EventClassProximityOut);
+                    APPEND_EVENT_CLASS(EventClassButtonPress);
+                    APPEND_EVENT_CLASS(EventClassButtonRelease);
 
                     #undef APPEND_EVENT_CLASS
                 } break;
@@ -865,10 +867,22 @@ EasyTabResult EasyTab_HandleEvent(XEvent* Event)
     else if (Event->type == EasyTab->ButtonTypePress)
     {
         // TODO: Buttons
+        // Done lower and upper buttons - tested on wacom one
+        XDeviceButtonPressedEvent* ButtonEvent = (XDeviceButtonPressedEvent*)(Event);
+        if(ButtonEvent->button == Button2)
+                EasyTab->Buttons |= EasyTab_Buttons_Pen_Lower;
+        else if(ButtonEvent->button == Button3)
+                EasyTab->Buttons |= EasyTab_Buttons_Pen_Upper;
     }
     else if (Event->type == EasyTab->ButtonTypeRelease)
     {
 
+        // Done lower and upper buttons - tested on wacom one
+        XDeviceButtonPressedEvent* ButtonEvent = (XDeviceButtonPressedEvent*)(Event);
+        if(ButtonEvent->button == Button2)
+                EasyTab->Buttons &= ~EasyTab_Buttons_Pen_Lower;
+        else if(ButtonEvent->button == Button3)
+                EasyTab->Buttons &= ~EasyTab_Buttons_Pen_Upper;
     }
     else
     {

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -815,6 +815,51 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform,  Milton* milton, 
                     milton->settings->peek_out_increment = (peek_out_percent / 100.0f) * peek_range;
                 }
 
+                if(platform->platform_can_configure_stylus) {
+                    char result[50];   // array to hold the result.
+                    ImGui::Separator();
+
+                    ImGui::Text(loc(TXT_stylus_upper_button_function));
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_default), "##upper");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_upper_button, STYLUS_DEFAULT);
+                    ImGui::SameLine();
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_eraser), "##upper");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_upper_button, STYLUS_ERASER);
+                    ImGui::SameLine();
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_brush), "##upper");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_upper_button, STYLUS_BRUSH);
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_decrease_brush_size), "##upper");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_upper_button, STYLUS_DECB);
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_increase_brush_size), "##upper");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_upper_button, STYLUS_INCB);
+
+                    ImGui::Separator();
+
+                    ImGui::Text(loc(TXT_stylus_lower_button_function));
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_default), "##lower");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_DEFAULT);
+                    ImGui::SameLine();
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_eraser), "##lower");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_ERASER);
+                    ImGui::SameLine();
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_brush), "##lower");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_BRUSH);
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_decrease_brush_size), "##lower");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_DECB);
+
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_increase_brush_size), "##lower");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_INCB);
+                }
+
                 ImGui::Separator();
 
                 MiltonBindings* bs = &milton->settings->bindings;

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -829,6 +829,10 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform,  Milton* milton, 
                     ImGui::RadioButton(result, (int*)&milton->settings->stylus_upper_button, STYLUS_ERASER);
                     ImGui::SameLine();
 
+                    snprintf(result, array_count(result), "%s%s", loc(TXT_Action_DRAG_ZOOM), "##upper");
+                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_upper_button, STYLUS_ZOOM);
+                    ImGui::SameLine();
+
                     snprintf(result, array_count(result), "%s%s", loc(TXT_brush), "##upper");
                     ImGui::RadioButton(result, (int*)&milton->settings->stylus_upper_button, STYLUS_BRUSH);
 
@@ -837,27 +841,6 @@ milton_imgui_tick(MiltonInput* input, PlatformState* platform,  Milton* milton, 
 
                     snprintf(result, array_count(result), "%s%s", loc(TXT_increase_brush_size), "##upper");
                     ImGui::RadioButton(result, (int*)&milton->settings->stylus_upper_button, STYLUS_INCB);
-
-                    ImGui::Separator();
-
-                    ImGui::Text(loc(TXT_stylus_lower_button_function));
-
-                    snprintf(result, array_count(result), "%s%s", loc(TXT_default), "##lower");
-                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_DEFAULT);
-                    ImGui::SameLine();
-
-                    snprintf(result, array_count(result), "%s%s", loc(TXT_eraser), "##lower");
-                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_ERASER);
-                    ImGui::SameLine();
-
-                    snprintf(result, array_count(result), "%s%s", loc(TXT_brush), "##lower");
-                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_BRUSH);
-
-                    snprintf(result, array_count(result), "%s%s", loc(TXT_decrease_brush_size), "##lower");
-                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_DECB);
-
-                    snprintf(result, array_count(result), "%s%s", loc(TXT_increase_brush_size), "##lower");
-                    ImGui::RadioButton(result, (int*)&milton->settings->stylus_lower_button, STYLUS_INCB);
                 }
 
                 ImGui::Separator();

--- a/src/localization.cc
+++ b/src/localization.cc
@@ -117,6 +117,9 @@ init_localization()
         EN(TXT_size_relative_to_canvas, "Size relative to canvas");
         EN(TXT_grid_columns, "Grid Columns");
         EN(TXT_grid_rows, "Grid Rows");
+        EN(TXT_default, "Default");
+        EN(TXT_stylus_lower_button_function, "Stylus Lower Button Function");
+        EN(TXT_stylus_upper_button_function, "Stylus Upper Button Function");
 
         EN(TXT_Action_DECREASE_BRUSH_SIZE, "Decrease brush size");
         EN(TXT_Action_INCREASE_BRUSH_SIZE, "Increase brush size");

--- a/src/localization.cc
+++ b/src/localization.cc
@@ -118,7 +118,6 @@ init_localization()
         EN(TXT_grid_columns, "Grid Columns");
         EN(TXT_grid_rows, "Grid Rows");
         EN(TXT_default, "Default");
-        EN(TXT_stylus_lower_button_function, "Stylus Lower Button Function");
         EN(TXT_stylus_upper_button_function, "Stylus Upper Button Function");
 
         EN(TXT_Action_DECREASE_BRUSH_SIZE, "Decrease brush size");

--- a/src/localization.h
+++ b/src/localization.h
@@ -100,6 +100,10 @@ enum Texts
     TXT_size_relative_to_canvas,
     TXT_grid_columns,
     TXT_grid_rows,
+    TXT_default,
+    TXT_stylus_lower_button_function,
+    TXT_stylus_upper_button_function,
+
 
     // Actions
     TXT_Action_FIRST,

--- a/src/localization.h
+++ b/src/localization.h
@@ -101,7 +101,6 @@ enum Texts
     TXT_grid_columns,
     TXT_grid_rows,
     TXT_default,
-    TXT_stylus_lower_button_function,
     TXT_stylus_upper_button_function,
 
 

--- a/src/milton.cc
+++ b/src/milton.cc
@@ -1386,6 +1386,27 @@ transform_tick(Milton* milton, MiltonInput const* input)
     }
 }
 
+void stylus_buttons_exec_function(MiltonInput *milton_input, Milton *milton, StylusButtonFunction mode)
+{
+    switch (mode) {
+        case STYLUS_DEFAULT:
+            break;
+        case STYLUS_ERASER:
+            milton_input->mode_to_set = MiltonMode::ERASER;
+            break;
+        case STYLUS_BRUSH:
+            milton_input->mode_to_set = MiltonMode::PEN;
+            break;
+        case STYLUS_DECB:
+            for (int i=0;i<5;++i) milton_decrease_brush_size(milton);
+            break;
+        case STYLUS_INCB:
+            for (int i=0;i<5;++i) milton_increase_brush_size(milton);
+            break;
+    }
+}
+
+
 void
 milton_update_and_render(Milton* milton, MiltonInput const* input)
 {

--- a/src/milton.cc
+++ b/src/milton.cc
@@ -1403,6 +1403,9 @@ void stylus_buttons_exec_function(MiltonInput *milton_input, Milton *milton, Sty
         case STYLUS_INCB:
             for (int i=0;i<5;++i) milton_increase_brush_size(milton);
             break;
+	case STYLUS_ZOOM:
+            milton_input->mode_to_set = MiltonMode::DRAG_ZOOM;
+	    break;
     }
 }
 

--- a/src/milton.h
+++ b/src/milton.h
@@ -384,3 +384,5 @@ void drag_brush_size_stop(Milton* milton);
 
 void drag_zoom_start(Milton* milton, v2i pointer);
 void drag_zoom_stop(Milton* milton);
+
+void stylus_buttons_exec_function(MiltonInput *milton_input, Milton *milton, StylusButtonFunction mode);

--- a/src/milton.h
+++ b/src/milton.h
@@ -98,11 +98,23 @@ enum PrimitiveFSM
     Primitive_DONE,
 };
 
+enum StylusButtonFunction
+{
+    STYLUS_DEFAULT,
+    STYLUS_ERASER,
+    STYLUS_BRUSH,
+    STYLUS_DECB,
+    STYLUS_INCB,
+};
+
 #pragma pack(push, 1)
 struct MiltonSettings
 {
     v3f background_color;
     float peek_out_increment;
+
+    StylusButtonFunction stylus_upper_button;
+    StylusButtonFunction stylus_lower_button;
 
     MiltonBindings bindings;
 };

--- a/src/milton.h
+++ b/src/milton.h
@@ -105,6 +105,7 @@ enum StylusButtonFunction
     STYLUS_BRUSH,
     STYLUS_DECB,
     STYLUS_INCB,
+    STYLUS_ZOOM,
 };
 
 #pragma pack(push, 1)
@@ -114,7 +115,7 @@ struct MiltonSettings
     float peek_out_increment;
 
     StylusButtonFunction stylus_upper_button;
-    StylusButtonFunction stylus_lower_button;
+    StylusButtonFunction stylus_upper_ctrl_button;
 
     MiltonBindings bindings;
 };
@@ -294,6 +295,7 @@ struct MiltonInput
 {
     int flags;  // MiltonInputFlags
     MiltonMode mode_to_set;
+    MiltonMode saved_mode;
 
     v2l  points[MAX_INPUT_BUFFER_ELEMS];
     f32  pressures[MAX_INPUT_BUFFER_ELEMS];

--- a/src/platform.h
+++ b/src/platform.h
@@ -84,6 +84,10 @@ struct PlatformState
     PlatformSpecific* specific;
 
     float ui_scale;
+
+    bool platform_can_configure_stylus;
+    int stylus_upper_button_pressed;
+    int stylus_lower_button_pressed;
 };
 
 typedef enum HistoryDebug

--- a/src/platform.h
+++ b/src/platform.h
@@ -87,7 +87,6 @@ struct PlatformState
 
     bool platform_can_configure_stylus;
     int stylus_upper_button_pressed;
-    int stylus_lower_button_pressed;
 };
 
 typedef enum HistoryDebug

--- a/src/platform_linux.cc
+++ b/src/platform_linux.cc
@@ -39,6 +39,7 @@ platform_init(PlatformState* platform, SDL_SysWMinfo* sysinfo)
     mlt_assert(sysinfo->subsystem == SDL_SYSWM_X11);
     gtk_init(NULL, NULL);
     EasyTab_Load(sysinfo->info.x11.display, sysinfo->info.x11.window);
+    platform->platform_can_configure_stylus = true;
 }
 
 EasyTabResult

--- a/src/platform_mac.mm
+++ b/src/platform_mac.mm
@@ -29,7 +29,7 @@
 void
 platform_init(PlatformState* platform, SDL_SysWMinfo* sysinfo)
 {
-
+    platform->platform_can_configure_stylus = false;
 }
 
 void

--- a/src/platform_windows.cc
+++ b/src/platform_windows.cc
@@ -77,6 +77,7 @@ platform_init(PlatformState* platform, SDL_SysWMinfo* sysinfo)
         milton_log("EasyTab failed to load. Code %d\n", easytab_res);
     }
 
+    platform->platform_can_configure_stylus = false;
 }
 
 void

--- a/src/sdl_milton.cc
+++ b/src/sdl_milton.cc
@@ -214,6 +214,28 @@ panning_update(PlatformState* platform)
     }
 }
 
+static void stylus_buttons_exec_function(MiltonInput *milton_input,
+                                         Milton *milton,
+                                         StylusButtonFunction mode)
+{
+    switch (mode) {
+        case STYLUS_DEFAULT:
+            break;
+        case STYLUS_ERASER:
+            milton_input->mode_to_set = MiltonMode::ERASER;
+            break;
+        case STYLUS_BRUSH:
+            milton_input->mode_to_set = MiltonMode::PEN;
+            break;
+        case STYLUS_DECB:
+            for (int i=0;i<5;++i) milton_decrease_brush_size(milton);
+            break;
+        case STYLUS_INCB:
+            for (int i=0;i<5;++i) milton_increase_brush_size(milton);
+            break;
+    }
+}
+
 MiltonInput
 sdl_event_loop(Milton* milton, PlatformState* platform)
 {
@@ -270,6 +292,32 @@ sdl_event_loop(Milton* milton, PlatformState* platform)
                     b32 taking_pen_input = EasyTab->PenInProximity
                                            && bit_touch
                                            && !( bit_upper || bit_lower );
+
+                    if (platform->platform_can_configure_stylus) {
+                        // Save lower and upper button status from the stylus - otherwise it returns
+                        // being pressed all the time
+                        if(bit_lower && !platform->stylus_lower_button_pressed) {
+                            platform->stylus_lower_button_pressed = true;
+                            stylus_buttons_exec_function(&milton_input,
+                                                         milton,
+                                                         milton->settings->stylus_lower_button);
+                        }
+
+                        if(!bit_lower && platform->stylus_lower_button_pressed) {
+                            platform->stylus_lower_button_pressed = false;
+                        }
+
+                        if(bit_upper && !platform->stylus_upper_button_pressed) {
+                            platform->stylus_upper_button_pressed = true;
+                            stylus_buttons_exec_function(&milton_input,
+                                                         milton,
+                                                         milton->settings->stylus_upper_button);
+                        }
+
+                        if(!bit_upper && platform->stylus_upper_button_pressed) {
+                            platform->stylus_upper_button_pressed = false;
+                        }
+                    }
 
                     if ( taking_pen_input ) {
                         platform->is_pointer_down = true;

--- a/src/sdl_milton.cc
+++ b/src/sdl_milton.cc
@@ -214,28 +214,6 @@ panning_update(PlatformState* platform)
     }
 }
 
-static void stylus_buttons_exec_function(MiltonInput *milton_input,
-                                         Milton *milton,
-                                         StylusButtonFunction mode)
-{
-    switch (mode) {
-        case STYLUS_DEFAULT:
-            break;
-        case STYLUS_ERASER:
-            milton_input->mode_to_set = MiltonMode::ERASER;
-            break;
-        case STYLUS_BRUSH:
-            milton_input->mode_to_set = MiltonMode::PEN;
-            break;
-        case STYLUS_DECB:
-            for (int i=0;i<5;++i) milton_decrease_brush_size(milton);
-            break;
-        case STYLUS_INCB:
-            for (int i=0;i<5;++i) milton_increase_brush_size(milton);
-            break;
-    }
-}
-
 MiltonInput
 sdl_event_loop(Milton* milton, PlatformState* platform)
 {

--- a/src/sdl_milton.cc
+++ b/src/sdl_milton.cc
@@ -268,32 +268,25 @@ sdl_event_loop(Milton* milton, PlatformState* platform)
 
                     // Pen in use but not drawing
                     b32 taking_pen_input = EasyTab->PenInProximity
-                                           && bit_touch
-                                           && !( bit_upper || bit_lower );
+                                           && bit_touch;
+                                           // && !( bit_upper || bit_lower );
 
                     if (platform->platform_can_configure_stylus) {
                         // Save lower and upper button status from the stylus - otherwise it returns
                         // being pressed all the time
-                        if(bit_lower && !platform->stylus_lower_button_pressed) {
-                            platform->stylus_lower_button_pressed = true;
-                            stylus_buttons_exec_function(&milton_input,
-                                                         milton,
-                                                         milton->settings->stylus_lower_button);
-                        }
-
-                        if(!bit_lower && platform->stylus_lower_button_pressed) {
-                            platform->stylus_lower_button_pressed = false;
-                        }
-
                         if(bit_upper && !platform->stylus_upper_button_pressed) {
+			    milton_input.saved_mode = milton->current_mode;
                             platform->stylus_upper_button_pressed = true;
                             stylus_buttons_exec_function(&milton_input,
                                                          milton,
                                                          milton->settings->stylus_upper_button);
+			    drag_zoom_start(milton, platform->pointer);
                         }
 
                         if(!bit_upper && platform->stylus_upper_button_pressed) {
                             platform->stylus_upper_button_pressed = false;
+			    milton_input.mode_to_set = milton_input.saved_mode;
+			    drag_zoom_stop(milton);
                         }
                     }
 

--- a/third_party/SDL2-2.0.8/CMakeLists.txt
+++ b/third_party/SDL2-2.0.8/CMakeLists.txt
@@ -2,7 +2,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "Prevented in-tree built. Please create a build directory outside of the SDL source code and call cmake from there")
 endif()
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.5)
 project(SDL2 C)
 
 # !!! FIXME: this should probably do "MACOSX_RPATH ON" as a target property


### PR DESCRIPTION
I added two entries in the settings menu to give stylus buttons some common functionalities. While being able to change the lower button bind to for example "switch to brush" it is still able to pan the canvas (this allows some function on the upper button and pan + return to brush on the lower one). All code running is inside #ifdef __linux__ clauses as on windows stylus buttons functions are defined with the gui driver

![Screenshot-2023-05-29-14:54:28](https://github.com/serge-rgb/milton/assets/78708062/9379cd21-23ea-4529-b708-ffa30ba07a5c)

All changes in the settings for the stylus are persistent. For now only functions that came to my mind were switch to brush and eraser and changing the size of the brush (as these are the ones I use the most probably)
 